### PR TITLE
fix: 사운드 프리로드 완료 전 로딩 인디케이터가 닫히는 문제 수정

### DIFF
--- a/Keychy/Keychy/Features/Workshop/Making/Shared/Views/KeyringCustomizingView.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Shared/Views/KeyringCustomizingView.swift
@@ -67,21 +67,18 @@ struct KeyringCustomizingView<VM: KeyringViewModelProtocol>: View {
         .task {
             // 커스터마이징 화면 진입 시 모든 사운드 리소스 프리로드
             // TODO: Firebase 연동 후에는 유저 소유 사운드만 프리로드하도록 변경
-            await preloadAllSoundEffects()
-            isLoadingResources = false
+            await preloadAllSoundEffects()  // 모든 사운드 로딩 완료까지 기다림
+            isLoadingResources = false      // 로딩 완료 후 인디케이터 닫기
         }
     }
 
     // MARK: - Preload Sound Resources
     private func preloadAllSoundEffects() async {
-        // 백그라운드 스레드에서 사운드 파일 프리로드
-        // 함수 호출만 메인에서 함.
-        await Task(priority: .userInitiated) {
-            SoundEffect.allCases.forEach { effect in
-                guard effect != .none else { return }
-                SoundEffectComponent.shared.preloadSound(named: effect.soundFileName)
-            }
-        }.value
+        // 모든 사운드를 순차적으로 로드 (각각 완료될 때까지 기다림)
+        for effect in SoundEffect.allCases {
+            guard effect != .none else { continue }
+            await SoundEffectComponent.shared.preloadSound(named: effect.soundFileName)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->
- preloadSound()를 async 함수로 변경 (withCheckedContinuation 을 활용)
- 실제 로딩이 전부 완료될 때까지 await로 대기! -> continuation.resume()로 재개하는 방식입니다요
- 불필요한 Task 중첩 제거 (세오 나이스)


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->
- 실제 동작이 현재는 똑같아보이지만, 사운드가 많아졌다면 차이가 났을겁니다.

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
