### PR TITLE
feat: Core/Componets/CategoryTabBar.swift 생성

### DIFF
--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		AA9B2E8B2EB001B70004D31C /* Carabiner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B2E8A2EB001B70004D31C /* Carabiner.swift */; };
 		AA9B2E8D2EB0027D0004D31C /* BundleSelectCarabinerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B2E8C2EB0027D0004D31C /* BundleSelectCarabinerView.swift */; };
 		AA9B2E912EB081750004D31C /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B2E902EB081750004D31C /* ItemDetailView.swift */; };
+		C645AE9F2EB1055C004BFE69 /* CategoryTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C645AE9E2EB1055C004BFE69 /* CategoryTabBar.swift */; };
 		C665DDE82EAEFA8700CE4495 /* CoinChargeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C665DDE72EAEFA8700CE4495 /* CoinChargeView.swift */; };
 		C665DDEC2EAF064500CE4495 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C665DDEB2EAF064500CE4495 /* StoreKit.framework */; };
 		C665DDEE2EAF077900CE4495 /* Product.storekit in Resources */ = {isa = PBXBuildFile; fileRef = C665DDED2EAF077900CE4495 /* Product.storekit */; };
@@ -243,6 +244,7 @@
 		AA9B2E8A2EB001B70004D31C /* Carabiner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Carabiner.swift; sourceTree = "<group>"; };
 		AA9B2E8C2EB0027D0004D31C /* BundleSelectCarabinerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleSelectCarabinerView.swift; sourceTree = "<group>"; };
 		AA9B2E902EB081750004D31C /* ItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailView.swift; sourceTree = "<group>"; };
+		C645AE9E2EB1055C004BFE69 /* CategoryTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTabBar.swift; sourceTree = "<group>"; };
 		C665DDE72EAEFA8700CE4495 /* CoinChargeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinChargeView.swift; sourceTree = "<group>"; };
 		C665DDEB2EAF064500CE4495 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		C665DDED2EAF077900CE4495 /* Product.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; name = Product.storekit; path = Keychy/Resources/Product.storekit; sourceTree = "<group>"; };
@@ -478,6 +480,7 @@
 			children = (
 				4CEC61F32EAE08DA0099ECEE /* KeyringCellScene.swift */,
 				4CEC61F42EAE08DA0099ECEE /* KeyringCellScene+Setup.swift */,
+				C645AE9E2EB1055C004BFE69 /* CategoryTabBar.swift */,
 				4CEC61F82EAE08DA0099ECEE /* View */,
 				4CEC62022EAE08DA0099ECEE /* Keyring */,
 				4CEC62052EAE08DA0099ECEE /* Effects */,
@@ -985,12 +988,12 @@
 				4CEC626C2EAE08DF0099ECEE /* FestivalView.swift in Sources */,
 				4CEC626D2EAE08DF0099ECEE /* WorkshopTab.swift in Sources */,
 				38A596862EAFF8200003D712 /* IntroViewModel+NicknameSetup.swift in Sources */,
-				4CEC626E2EAE08DF0099ECEE /* MKPhotoCropView.swift in Sources */,
+				4CEC626E2EAE08DF0099ECEE /* ArcylicPhotoCropView.swift in Sources */,
 				4CEC626E2EAE08DF0099ECEE /* ArcylicPhotoCropView.swift in Sources */,
 				4CEC62702EAE08DF0099ECEE /* KeyringInfoInputView.swift in Sources */,
 				4C6622322EAF6AF7001760B5 /* Typography.swift in Sources */,
 				4CEC62712EAE08DF0099ECEE /* HomeTab.swift in Sources */,
-				4CEC62722EAE08DF0099ECEE /* MKViewModel.swift in Sources */,
+				4CEC62722EAE08DF0099ECEE /* ArcylicPhotoVM.swift in Sources */,
 				38A5967C2EAFA95C0003D712 /* IntroViewModel.swift in Sources */,
 				4CEC62722EAE08DF0099ECEE /* ArcylicPhotoVM.swift in Sources */,
 				4CEC62A72EAE0C130099ECEE /* LottieView.swift in Sources */,
@@ -1008,7 +1011,7 @@
 				4CEC62A02EAE09990099ECEE /* BundleInventoryView.swift in Sources */,
 				4CEC62A12EAE09990099ECEE /* BundleSelectBackgroundView.swift in Sources */,
 				38A596782EAFA9430003D712 /* SplashView.swift in Sources */,
-				4CEC627B2EAE08DF0099ECEE /* MKPreviewView.swift in Sources */,
+				4CEC627B2EAE08DF0099ECEE /* ArcylicPhotoPreView.swift in Sources */,
 				4CEC627B2EAE08DF0099ECEE /* ArcylicPhotoPreView.swift in Sources */,
 				4CEC627C2EAE08DF0099ECEE /* WorkshopView.swift in Sources */,
 				4CEC627D2EAE08DF0099ECEE /* KeyringViewModelProtocol.swift in Sources */,
@@ -1017,7 +1020,7 @@
 				4CEC62812EAE08DF0099ECEE /* KeyringCustomizingView.swift in Sources */,
 				4CEC62842EAE08DF0099ECEE /* ArcylicPhotoVM+Crop.swift in Sources */,
 				4CEC62852EAE08DF0099ECEE /* CollectionViewModel.swift in Sources */,
-				4CEC62862EAE08DF0099ECEE /* MKViewModel+BGRemover.swift in Sources */,
+				4CEC62862EAE08DF0099ECEE /* ArcylicPhotoVM+BGRemover.swift in Sources */,
 				38A596842EAFEAA20003D712 /* ProfileSetupView.swift in Sources */,
 				4CEC62862EAE08DF0099ECEE /* ArcylicPhotoVM+BGRemover.swift in Sources */,
 				4CEC622C2EAE08DA0099ECEE /* KeyringSceneView.swift in Sources */,
@@ -1026,6 +1029,7 @@
 				4CEC622D2EAE08DA0099ECEE /* KeyringScene+Setup.swift in Sources */,
 				4CEC622E2EAE08DA0099ECEE /* KeyringCellScene+Setup.swift in Sources */,
 				4C6622102EAE67CE001760B5 /* HomeViewModel+Bundle.swift in Sources */,
+				C645AE9F2EB1055C004BFE69 /* CategoryTabBar.swift in Sources */,
 				4CEC622F2EAE08DA0099ECEE /* NavigationRouter.swift in Sources */,
 				4CEC62302EAE08DA0099ECEE /* KeyringScene+Effects.swift in Sources */,
 				4CEC62312EAE08DA0099ECEE /* KeyringScene+Swipe.swift in Sources */,

--- a/Keychy/Keychy/Core/Components/CategoryTabBar.swift
+++ b/Keychy/Keychy/Core/Components/CategoryTabBar.swift
@@ -1,0 +1,95 @@
+//
+//  CategoryTabBar.swift
+//  Keychy
+//
+//  Created by rundo on 10/28/25.
+//
+
+import SwiftUI
+
+/// 가로 스크롤 카테고리 탭바
+///
+/// 카테고리를 선택할 수 있는 가로 스크롤 탭바입니다.
+/// 선택된 카테고리는 보라색 강조와 밑줄로 표시됩니다.
+///
+/// **사용 예시:**
+/// ```swift
+/// @State private var selectedCategory = "키링"
+/// let categories = ["KEYCHY!", "키링", "카라비너", "이펫트", "배경"]
+///
+/// CategoryTabBar(
+///     categories: categories,
+///     selectedCategory: $selectedCategory
+/// )
+/// ```
+struct CategoryTabBar: View {
+    /// 표시할 카테고리 목록
+    let categories: [String]
+    
+    /// 현재 선택된 카테고리
+    @Binding var selectedCategory: String
+    
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 28) {
+                ForEach(categories, id: \.self) { category in
+                    CategoryTabButton(
+                        title: category,
+                        isSelected: selectedCategory == category
+                    ) {
+                        selectedCategory = category
+                    }
+                }
+            }
+        }
+        .scrollBounceBehavior(.basedOnSize)
+    }
+}
+
+// MARK: - Category Tab Button
+
+/// 카테고리 탭 버튼
+///
+/// 선택 상태에 따라 스타일이 변경되는 버튼입니다.
+/// - 선택됨: 굵은 폰트 + 보라색 + 밑줄
+/// - 미선택: 일반 폰트 + 검정색 + 밑줄 없음
+private struct CategoryTabButton: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: Spacing.sm) {
+                Text(title)
+                    .typography(isSelected ? .suit14EB25 : .suit15SB25)
+                    .foregroundStyle(isSelected ? Color.main500 : Color.black100)
+                
+                Rectangle()
+                    .fill(isSelected ? Color.main500 : Color.clear)
+                    .frame(height: 2)
+            }
+        }
+        .buttonStyle(.plain)
+        .transaction { transaction in
+            transaction.animation = nil
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("예시 프리뷰") {
+    @Previewable @State var selectedCategory = "키링"
+    let categories = ["KEYCHY!", "키링", "카라비너", "이펫트", "배경"]
+    
+    VStack() {
+        CategoryTabBar(
+            categories: categories,
+            selectedCategory: $selectedCategory
+        )
+        
+        Spacer()
+    }
+    .padding()
+}


### PR DESCRIPTION
## 🎯 PR 내용
- Core/Componets/CategoryTabBar.swift를 만들었습니다.
- 카테고리 탭바 입니다.
## 📱 스크린샷 (UI 변경 시)
<img width="200" alt="스크린샷 2025-10-28 23 33 45" src="https://github.com/user-attachments/assets/2990aadb-224e-4c95-b644-34974d7955ff" />

## 🔗 관련 이슈
- 보관함, 공방에서 사용하면 될 듯
- 각 탭을 눌렀을 때 나오는 애니메이션은 버튼 기본 에니메이션입니다.
- 일단 경로는 Core/Componets/CategoryTabBar.swift 로 했어요.
- 각 카테고리 케이스들을 enum으로 설정해서 사용했을 때 컴포넌트화가 복잡해져서 [String]을 선언해서 사용하는게 좋겠다고 판단햇어요.



## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
