### PR TITLE
refactor: KeychyUser 구조 UserManager 리팩토링 및 필드 마이그레이션 추가

### DIFF
--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -15,14 +15,8 @@
 		38A594462EAE4EE20003D712 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 38A594452EAE4EE20003D712 /* FirebaseMessaging */; };
 		38A594482EAE4EE20003D712 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 38A594472EAE4EE20003D712 /* FirebaseStorage */; };
 		38A596732EAFA8D20003D712 /* KeychyUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A596722EAFA8D20003D712 /* KeychyUser.swift */; };
-		38A596782EAFA9430003D712 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A596772EAFA9430003D712 /* SplashView.swift */; };
 		38A5967A2EAFA94E0003D712 /* IntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A596792EAFA94E0003D712 /* IntroView.swift */; };
-		38A5967C2EAFA95C0003D712 /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A5967B2EAFA95C0003D712 /* IntroViewModel.swift */; };
-		38A5967E2EAFBB740003D712 /* IntroViewModel+Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A5967D2EAFBB740003D712 /* IntroViewModel+Login.swift */; };
 		38A596802EAFCF5F0003D712 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A5967F2EAFCF5F0003D712 /* UserManager.swift */; };
-		38A596822EAFE7DB0003D712 /* IntroViewModel+Signup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A596812EAFE7DB0003D712 /* IntroViewModel+Signup.swift */; };
-		38A596842EAFEAA20003D712 /* ProfileSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A596832EAFEAA20003D712 /* ProfileSetupView.swift */; };
-		38A596862EAFF8200003D712 /* IntroViewModel+NicknameSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A596852EAFF8200003D712 /* IntroViewModel+NicknameSetup.swift */; };
 		4C6621DB2EAE0D93001760B5 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 4C6621DA2EAE0D93001760B5 /* Lottie */; };
 		4C6622052EAE5FC3001760B5 /* SUIT-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4C6621FB2EAE5FC3001760B5 /* SUIT-Bold.otf */; };
 		4C6622062EAE5FC3001760B5 /* SUIT-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4C6621FC2EAE5FC3001760B5 /* SUIT-ExtraBold.otf */; };
@@ -46,6 +40,11 @@
 		4C7775322EB0EEF100981C3E /* PreviewImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7775312EB0EEF100981C3E /* PreviewImage.swift */; };
 		4C7775342EB0EF8800981C3E /* PreviewInfoSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7775332EB0EF8800981C3E /* PreviewInfoSection.swift */; };
 		4C7775382EB0EFD800981C3E /* PreviewMakingBtn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7775372EB0EFD800981C3E /* PreviewMakingBtn.swift */; };
+		4C77753E2EB1343600981C3E /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7775392EB1343600981C3E /* IntroViewModel.swift */; };
+		4C77753F2EB1343600981C3E /* IntroViewModel+Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C77753A2EB1343600981C3E /* IntroViewModel+Login.swift */; };
+		4C7775402EB1343600981C3E /* IntroViewModel+Signup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C77753C2EB1343600981C3E /* IntroViewModel+Signup.swift */; };
+		4C7775412EB1343600981C3E /* IntroViewModel+NicknameSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C77753B2EB1343600981C3E /* IntroViewModel+NicknameSetup.swift */; };
+		4C84A1602EB134BD008FFE57 /* ProfileSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A596832EAFEAA20003D712 /* ProfileSetupView.swift */; };
 		4CEC61E52EAE08C00099ECEE /* KeyringBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEC61D82EAE08C00099ECEE /* KeyringBundle.swift */; };
 		4CEC61E62EAE08C00099ECEE /* Keyring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEC61DF2EAE08C00099ECEE /* Keyring.swift */; };
 		4CEC61E72EAE08C00099ECEE /* SoundEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEC61DC2EAE08C00099ECEE /* SoundEffect.swift */; };
@@ -146,12 +145,8 @@
 		38A596722EAFA8D20003D712 /* KeychyUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychyUser.swift; sourceTree = "<group>"; };
 		38A596772EAFA9430003D712 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		38A596792EAFA94E0003D712 /* IntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroView.swift; sourceTree = "<group>"; };
-		38A5967B2EAFA95C0003D712 /* IntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModel.swift; sourceTree = "<group>"; };
-		38A5967D2EAFBB740003D712 /* IntroViewModel+Login.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntroViewModel+Login.swift"; sourceTree = "<group>"; };
 		38A5967F2EAFCF5F0003D712 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
-		38A596812EAFE7DB0003D712 /* IntroViewModel+Signup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntroViewModel+Signup.swift"; sourceTree = "<group>"; };
 		38A596832EAFEAA20003D712 /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
-		38A596852EAFF8200003D712 /* IntroViewModel+NicknameSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntroViewModel+NicknameSetup.swift"; sourceTree = "<group>"; };
 		4C6621FB2EAE5FC3001760B5 /* SUIT-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SUIT-Bold.otf"; sourceTree = "<group>"; };
 		4C6621FC2EAE5FC3001760B5 /* SUIT-ExtraBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SUIT-ExtraBold.otf"; sourceTree = "<group>"; };
 		4C6621FD2EAE5FC3001760B5 /* SUIT-ExtraLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SUIT-ExtraLight.otf"; sourceTree = "<group>"; };
@@ -175,6 +170,10 @@
 		4C7775312EB0EEF100981C3E /* PreviewImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewImage.swift; sourceTree = "<group>"; };
 		4C7775332EB0EF8800981C3E /* PreviewInfoSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewInfoSection.swift; sourceTree = "<group>"; };
 		4C7775372EB0EFD800981C3E /* PreviewMakingBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewMakingBtn.swift; sourceTree = "<group>"; };
+		4C7775392EB1343600981C3E /* IntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModel.swift; sourceTree = "<group>"; };
+		4C77753A2EB1343600981C3E /* IntroViewModel+Login.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntroViewModel+Login.swift"; sourceTree = "<group>"; };
+		4C77753B2EB1343600981C3E /* IntroViewModel+NicknameSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntroViewModel+NicknameSetup.swift"; sourceTree = "<group>"; };
+		4C77753C2EB1343600981C3E /* IntroViewModel+Signup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntroViewModel+Signup.swift"; sourceTree = "<group>"; };
 		4CEC61B12EAE071B0099ECEE /* Keychy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Keychy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CEC61D82EAE08C00099ECEE /* KeyringBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyringBundle.swift; sourceTree = "<group>"; };
 		4CEC61DA2EAE08C00099ECEE /* Interaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interaction.swift; sourceTree = "<group>"; };
@@ -281,8 +280,7 @@
 		38A596702EAFA8880003D712 /* Intro */ = {
 			isa = PBXGroup;
 			children = (
-				38A596742EAFA91C0003D712 /* Models */,
-				38A596752EAFA9200003D712 /* ViewModels */,
+				4C77753D2EB1343600981C3E /* ViewModels */,
 				38A596762EAFA9340003D712 /* Views */,
 			);
 			path = Intro;
@@ -294,24 +292,6 @@
 				38A596722EAFA8D20003D712 /* KeychyUser.swift */,
 			);
 			path = User;
-			sourceTree = "<group>";
-		};
-		38A596742EAFA91C0003D712 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
-		38A596752EAFA9200003D712 /* ViewModels */ = {
-			isa = PBXGroup;
-			children = (
-				38A5967B2EAFA95C0003D712 /* IntroViewModel.swift */,
-				38A596812EAFE7DB0003D712 /* IntroViewModel+Signup.swift */,
-				38A5967D2EAFBB740003D712 /* IntroViewModel+Login.swift */,
-				38A596852EAFF8200003D712 /* IntroViewModel+NicknameSetup.swift */,
-			);
-			path = ViewModels;
 			sourceTree = "<group>";
 		};
 		38A596762EAFA9340003D712 /* Views */ = {
@@ -360,6 +340,17 @@
 				4C7775372EB0EFD800981C3E /* PreviewMakingBtn.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		4C77753D2EB1343600981C3E /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				4C7775392EB1343600981C3E /* IntroViewModel.swift */,
+				4C77753A2EB1343600981C3E /* IntroViewModel+Login.swift */,
+				4C77753B2EB1343600981C3E /* IntroViewModel+NicknameSetup.swift */,
+				4C77753C2EB1343600981C3E /* IntroViewModel+Signup.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 		4CEC61A82EAE071B0099ECEE = {
@@ -976,13 +967,16 @@
 				4C6622152EAE70BF001760B5 /* Gradient+Keychy.swift in Sources */,
 				4CEC61F22EAE08C40099ECEE /* MainTabView.swift in Sources */,
 				4CEC61E82EAE08C00099ECEE /* ChainType.swift in Sources */,
+				4C77753E2EB1343600981C3E /* IntroViewModel.swift in Sources */,
+				4C77753F2EB1343600981C3E /* IntroViewModel+Login.swift in Sources */,
+				4C7775402EB1343600981C3E /* IntroViewModel+Signup.swift in Sources */,
+				4C7775412EB1343600981C3E /* IntroViewModel+NicknameSetup.swift in Sources */,
 				4CEC61E92EAE08C00099ECEE /* KeyringTemplate.swift in Sources */,
 				4CEC61EA2EAE08C00099ECEE /* RingType.swift in Sources */,
 				38A596802EAFCF5F0003D712 /* UserManager.swift in Sources */,
 				4CEC621A2EAE08DA0099ECEE /* KeyringScene.swift in Sources */,
 				4CEC621B2EAE08DA0099ECEE /* KeyringScene+Touch.swift in Sources */,
 				4CEC621C2EAE08DA0099ECEE /* SelectBackgroundGridItem.swift in Sources */,
-				38A596822EAFE7DB0003D712 /* IntroViewModel+Signup.swift in Sources */,
 				4CEC621D2EAE08DA0099ECEE /* HomeRoute.swift in Sources */,
 				38A5967A2EAFA94E0003D712 /* IntroView.swift in Sources */,
 				4CEC621E2EAE08DA0099ECEE /* KeyringChainComponent.swift in Sources */,
@@ -1011,6 +1005,7 @@
 				4C6622322EAF6AF7001760B5 /* Typography.swift in Sources */,
 				4CEC62712EAE08DF0099ECEE /* HomeTab.swift in Sources */,
 				4CEC62722EAE08DF0099ECEE /* AcrylicPhotoVM.swift in Sources */,
+				4C84A1602EB134BD008FFE57 /* ProfileSetupView.swift in Sources */,
 				4CEC62A72EAE0C130099ECEE /* LottieView.swift in Sources */,
 				4CEC62732EAE08DF0099ECEE /* AcrylicPhotoVM+CropBoxDrag.swift in Sources */,
 				4CEC62742EAE08DF0099ECEE /* AcrylicPhotoVM+ImageLoad.swift in Sources */,
@@ -1036,7 +1031,6 @@
 				4CEC62852EAE08DF0099ECEE /* CollectionViewModel.swift in Sources */,
 				4CEC62862EAE08DF0099ECEE /* AcrylicPhotoVM+BGRemover.swift in Sources */,
 				4CEC622C2EAE08DA0099ECEE /* KeyringSceneView.swift in Sources */,
-				38A5967E2EAFBB740003D712 /* IntroViewModel+Login.swift in Sources */,
 				AA9B2E892EB001AA0004D31C /* Background.swift in Sources */,
 				4CEC622D2EAE08DA0099ECEE /* KeyringScene+Setup.swift in Sources */,
 				4CEC622E2EAE08DA0099ECEE /* KeyringCellScene+Setup.swift in Sources */,

--- a/Keychy/Keychy/CommonModels/User/KeychyUser.swift
+++ b/Keychy/Keychy/CommonModels/User/KeychyUser.swift
@@ -6,8 +6,11 @@
 //
 
 import SwiftUI
+import FirebaseFirestore
 
-struct KeychyUser: Codable, Identifiable {
+struct KeychyUser: Identifiable {
+
+    // Firebase Auth UID (Firestore 문서 ID와 동일)
     var id: String
     var nickname: String
     var email: String
@@ -23,4 +26,68 @@ struct KeychyUser: Codable, Identifiable {
     var backgrounds: [String]
     var carabiners: [String]
     var tags: [String]
+
+    // MARK: - Firestore 변환
+    func toDictionary() -> [String: Any] {
+        return [
+            "nickname": nickname,
+            "email": email,
+            "createdAt": Timestamp(date: createdAt),
+            "maxKeyringCount": maxKeyringCount,
+            "coin": coin,
+            "copyVoucher": copyVoucher,
+            "templates": templates,
+            "rings": rings,
+            "chains": chains,
+            "soundEffects": soundEffects,
+            "particleEffects": particleEffects,
+            "backgrounds": backgrounds,
+            "carabiners": carabiners,
+            "tags": tags
+        ]
+    }
+
+    // Firestore DocumentSnapshot에서 초기화
+    init?(id: String, data: [String: Any]) {
+        guard let nickname = data["nickname"] as? String,
+              let email = data["email"] as? String,
+              let timestamp = data["createdAt"] as? Timestamp else {
+            return nil
+        }
+
+        self.id = id
+        self.nickname = nickname
+        self.email = email
+        self.createdAt = timestamp.dateValue()
+        self.maxKeyringCount = data["maxKeyringCount"] as? Int ?? 100
+        self.coin = data["coin"] as? Int ?? 0
+        self.copyVoucher = data["copyVoucher"] as? Int ?? 0
+        self.templates = data["templates"] as? [String] ?? []
+        self.rings = data["rings"] as? [String] ?? []
+        self.chains = data["chains"] as? [String] ?? []
+        self.soundEffects = data["soundEffects"] as? [String] ?? []
+        self.particleEffects = data["particleEffects"] as? [String] ?? []
+        self.backgrounds = data["backgrounds"] as? [String] ?? []
+        self.carabiners = data["carabiners"] as? [String] ?? []
+        self.tags = data["tags"] as? [String] ?? []
+    }
+
+    // 일반 초기화 (새 유저 생성용)
+    init(id: String, nickname: String, email: String) {
+        self.id = id
+        self.nickname = nickname
+        self.email = email
+        self.createdAt = Date()
+        self.maxKeyringCount = 100
+        self.coin = 0
+        self.copyVoucher = 0
+        self.templates = []
+        self.rings = []
+        self.chains = []
+        self.soundEffects = []
+        self.particleEffects = []
+        self.backgrounds = []
+        self.carabiners = []
+        self.tags = []
+    }
 }

--- a/Keychy/Keychy/Features/Intro/ViewModels/IntroViewModel+Signup.swift
+++ b/Keychy/Keychy/Features/Intro/ViewModels/IntroViewModel+Signup.swift
@@ -33,21 +33,24 @@ extension IntroViewModel {
             errorMessage = "사용자 정보를 찾을 수 없음"
             return
         }
-        
+
         print("사용자 입력 닉네임 저장: \(nickname)")
         isLoading = true
         errorMessage = nil
-        
-        UserManager.shared.saveProfile(
-            uid: tempUserUID,
+
+        // KeychyUser 객체 생성
+        let newUser = KeychyUser(
+            id: tempUserUID,
             nickname: nickname,
             email: tempUserEmail
-        ) { [weak self] success in
+        )
+
+        UserManager.shared.saveProfile(user: newUser) { [weak self] success in
             guard let self = self else { return }
-            
+
             DispatchQueue.main.async {
                 self.isLoading = false
-                
+
                 if success {
                     self.needsProfileSetup = false
                     self.isLoggedIn = true

--- a/Keychy/Keychy/Features/Intro/ViewModels/IntroViewModel.swift
+++ b/Keychy/Keychy/Features/Intro/ViewModels/IntroViewModel.swift
@@ -43,30 +43,13 @@ class IntroViewModel {
     
     // MARK: - 프로필 완성 여부 확인
     func checkProfileCompletion(uid: String) {
-        let db = Firestore.firestore()
-        
-        db.collection("User").document(uid).getDocument { [weak self] snapshot, error in
+        UserManager.shared.loadUserInfo(uid: uid) { [weak self] hasProfile in
             guard let self = self else { return }
-            
+
             DispatchQueue.main.async {
-                if let error = error {
-                    print("Firestore 로드 실패: \(error)")
-                    self.handleIncompleteProfile(uid: uid)
-                    return
-                }
-                
-                if let data = snapshot?.data(),
-                   let nickname = data["nickname"] as? String,
-                   !nickname.isEmpty {
+                if hasProfile {
                     // 프로필 완성 → 메인 진입
-                    print("프로필 완성됨 (닉네임: \(nickname)) → 메인 진입")
-                    
-                    UserManager.shared.userUID = uid
-                    UserManager.shared.userNickname = nickname
-                    UserManager.shared.userEmail = data["email"] as? String ?? Auth.auth().currentUser?.email ?? ""
-                    UserManager.shared.isLoaded = true
-                    UserManager.shared.saveToCache()
-                    
+                    print("프로필 완성됨 → 메인 진입")
                     self.isLoggedIn = true
                     self.needsProfileSetup = false
                 } else {

--- a/Keychy/Keychy/UserManager.swift
+++ b/Keychy/Keychy/UserManager.swift
@@ -12,130 +12,128 @@ import FirebaseFirestore
 @Observable
 class UserManager {
     static let shared = UserManager()
+
+    /// 유저 모델
+    var currentUser: KeychyUser?
     
-    var userNickname: String = ""
-    var userEmail: String = ""
-    var userUID: String = ""
     var isLoaded: Bool = false
-    
+
     private let db = Firestore.firestore()
-    
+
+    // 편의 접근 프로퍼티
+    var userUID: String { currentUser?.id ?? "" }
+    var userNickname: String { currentUser?.nickname ?? "" }
+    var userEmail: String { currentUser?.email ?? "" }
+
     private init() {
         loadFromCache()
     }
-    
-    // MARK: - 프로필 로드 (Firestore → 로컬)
-    func loadUserInfo(uid: String, completion: @escaping (Bool) -> Void) {
-        db.collection("User").document(uid).getDocument { [weak self] snapshot, error in
+
+    // MARK: - Firestore에 프로필 저장
+    func saveProfile(user: KeychyUser, completion: @escaping (Bool) -> Void) {
+        let userData = user.toDictionary()
+
+        db.collection("User").document(user.id).setData(userData, merge: true) { [weak self] error in
             guard let self = self else {
                 completion(false)
                 return
             }
-            
-            if let error = error {
-                print("Firestore 로드 에러: \(error)")
-                self.loadFromAuth(uid: uid)
-                completion(false)
-                return
-            }
-            
-            if let data = snapshot?.data(),
-               let nickname = data["nickname"] as? String,
-               !nickname.isEmpty {
-                // 프로필 완성
-                self.userUID = uid
-                self.userNickname = nickname
-                self.userEmail = data["email"] as? String ?? Auth.auth().currentUser?.email ?? ""
-                self.isLoaded = true
-                self.saveToCache()
-                
-                print("프로필 로드 완료: \(nickname)")
-                completion(true)
-            } else {
-                // 닉네임 없음
-                print("프로필 미완성")
-                completion(false)
-            }
-        }
-    }
-    
-    // MARK: - 프로필 저장 (로컬 + Firestore)
-    func saveProfile(uid: String, nickname: String, email: String, completion: @escaping (Bool) -> Void) {
-        let userData: [String: Any] = [
-            "nickname": nickname,
-            "email": email,
-            "createdAt": FieldValue.serverTimestamp(),
-        ]
-        
-        db.collection("User").document(uid).setData(userData, merge: true) { [weak self] error in
-            guard let self = self else {
-                completion(false)
-                return
-            }
-            
+
             if let error = error {
                 print("Firestore 저장 실패: \(error)")
                 completion(false)
             } else {
-                // 저장 성공 시 로컬 상태도 업데이트
-                self.userUID = uid
-                self.userNickname = nickname
-                self.userEmail = email
+                // 저장 성공 시 로컬 상태 업데이트
+                self.currentUser = user
                 self.isLoaded = true
                 self.saveToCache()
-                
-                // Auth에도 displayName 저장
-                if let user = Auth.auth().currentUser {
-                    let changeRequest = user.createProfileChangeRequest()
-                    changeRequest.displayName = nickname
-                    changeRequest.commitChanges { error in
-                        if let error = error {
-                            print("displayName 저장 실패: \(error)")
-                        }
-                    }
-                }
-                
                 print("프로필 저장 완료")
                 completion(true)
             }
         }
     }
     
-    private func loadFromAuth(uid: String) {
-        guard let user = Auth.auth().currentUser else { return }
-        userUID = uid
-        userNickname = user.displayName ?? "사용자"
-        userEmail = user.email ?? ""
-        isLoaded = true
-        saveToCache()
+    // MARK: - Firebase에서 프로필 로드
+    func loadUserInfo(uid: String, completion: @escaping (Bool) -> Void) {
+        db.collection("User").document(uid).getDocument { [weak self] snapshot, error in
+            guard let self = self else {
+                completion(false)
+                return
+            }
+
+            if let error = error {
+                print("Firestore 로드 에러: \(error)")
+                completion(false)
+                return
+            }
+
+            if let snapshot = snapshot,
+               snapshot.exists,
+               let data = snapshot.data(),
+               let user = KeychyUser(id: uid, data: data) {
+                // 프로필 로드 성공
+                self.currentUser = user
+                self.isLoaded = true
+                self.saveToCache()
+
+                // 필드 마이그레이션: 누락된 필드 자동 추가
+                self.migrateUserFieldsIfNeeded(user: user)
+
+                print("프로필 로드 완료: \(user.nickname)")
+                completion(true)
+            } else {
+                // 신규 유저 또는 프로필 미완성
+                print("프로필 미완성 - 회원가입 필요")
+                completion(false)
+            }
+        }
     }
-    
-    // MARK: - UserDefaults 캐시
+
+    // MARK: - UserDefaults 캐시 관리
     func saveToCache() {
-        UserDefaults.standard.set(userNickname, forKey: "userNickname")
-        UserDefaults.standard.set(userEmail, forKey: "userEmail")
-        UserDefaults.standard.set(userUID, forKey: "userUID")
+        guard let user = currentUser else { return }
+
+        UserDefaults.standard.set(user.id, forKey: "userUID")
+        UserDefaults.standard.set(user.nickname, forKey: "userNickname")
+        UserDefaults.standard.set(user.email, forKey: "userEmail")
     }
-    
+
     private func loadFromCache() {
-        userNickname = UserDefaults.standard.string(forKey: "userNickname") ?? ""
-        userEmail = UserDefaults.standard.string(forKey: "userEmail") ?? ""
-        userUID = UserDefaults.standard.string(forKey: "userUID") ?? ""
-        
-        if !userUID.isEmpty {
+        let uid = UserDefaults.standard.string(forKey: "userUID") ?? ""
+        let nickname = UserDefaults.standard.string(forKey: "userNickname") ?? ""
+        let email = UserDefaults.standard.string(forKey: "userEmail") ?? ""
+
+        if !uid.isEmpty {
+            // 캐시에서 임시 유저 생성 (전체 데이터는 Firestore에서 로드 필요)
+            currentUser = KeychyUser(
+                id: uid,
+                nickname: nickname,
+                email: email
+            )
             isLoaded = true
         }
     }
-    
+
+    // MARK: - 필드 마이그레이션
+    private func migrateUserFieldsIfNeeded(user: KeychyUser) {
+        // merge: true로 누락된 필드만 추가 (기존 데이터는 유지)
+        let userData = user.toDictionary()
+        db.collection("User").document(user.id).setData(userData, merge: true) { error in
+            if let error = error {
+                print("필드 마이그레이션 실패: \(error)")
+            } else {
+                print("필드 마이그레이션 완료")
+            }
+        }
+    }
+
     func clearUserInfo() {
-        userNickname = ""
-        userEmail = ""
-        userUID = ""
+        currentUser = nil
         isLoaded = false
-        
+
         UserDefaults.standard.removeObject(forKey: "userNickname")
         UserDefaults.standard.removeObject(forKey: "userEmail")
         UserDefaults.standard.removeObject(forKey: "userUID")
     }
-    
+
 }


### PR DESCRIPTION

## 🎯 PR 내용

### 작업 전,
기존에는 User의 필드가 파이어베이스 모두 등록되는 처리가 없었습니다.
그래서 User의 필드를 활용하는 코드를 작성하기 어려웠고, 
이 작업을 회원가입/로그인 때 모두 처리하도록 추가했습니다.

### 작업 후,
- KeychyUser 모델 기반의 UserManager 아키텍처로 리팩토링하고, 
- 기존 유저를 위한 자동 필드 마이그레이션 시스템을 구현했습니다.

## 작업 내용

### 1. KeychyUser 모델 개선
- Firestore 변환 로직 캡슐화
  `func toDictionary()` -> [String: Any]  // Firestore 저장용
  `init?(id: String, data: [String: Any]) ` // Firestore 로드용
  `init(id: String, nickname: String, email: String) ` // 새 유저 생성용

###  2. UserManager 리팩토링
- 아키텍처 변경
    - 개별 프로퍼티 관리 → currentUser: KeychyUser? 로 통합 관리!
    - 편의 접근 프로퍼티 추가: userUID, userNickname, userEmail

```
// Before
  saveProfile(uid: String, nickname: String, email: String)
```

```
// After
  saveProfile(user: KeychyUser)
```

  - 자동 필드 마이그레이션 추가
    - migrateUserFieldsIfNeeded(user:) 메서드 구현
    - 로그인 시 자동으로 누락된 필드 추가 (merge: true)
    - 기존 유저도 앱 업데이트 후 자동으로 새 필드 획득
  - 불필요한 코드 제거
    - loadFromAuth() 삭제 (신규 유저는 회원가입 플로우로)
    - Auth displayName 저장 로직 제거 (`Firestore가 Single Source of Truth`) -> 이거 아래에서 적어둘테니 읽어보세요.

### 3. IntroViewModel 업데이트
- IntroViewModel+Signup.swift
    - saveProfile() 호출 시 KeychyUser 객체 생성 방식으로 변경
- IntroViewModel.swift
    - checkProfileCompletion() 메서드를 UserManager.loadUserInfo() 사용하도록 변경
    - 중복 Firestore 접근 제거

## 개발하다보니, 혹은 나중에 업뎃해서 새로운 필드가 추가 된다면?
### KeychyUser.swift 파일만 수정하면됨!!

왜냐면 **자동 마이그레이션** 로직이 있기 때문.


### 4. Firestore의 Single Source of Truth (SSOT) 개념.

**Single Source of Truth: 모든 데이터가 하나의 신뢰할 수 있는 출처에서만 관리되고, 다른 곳은 그 데이터를 참조만 하는 아키텍처 패턴입니다.**


**예전 코드**
```
  // 1. Firestore에 저장
  db.collection("User").document(uid).setData([
      "nickname": "지훈"
  ])

  // 2. Auth에도 저장
  let changeRequest = user.createProfileChangeRequest()
  changeRequest.displayName = "지훈"  // ← 중복이잖여
```

  문제점:
  - 두 곳에 같은 데이터 (Firestore + Auth)
  - 닉네임 변경 시 두 곳 모두 수정 필요
  - 동기화 실패 가능성
  Firestore: "지훈"
  Auth:      "제갈지훈"  ← 불일치!
  - 어느 게 정답인지 모름 → 혼란

**현재 코드**
```
  // Firestore만 저장 (Single Source of Truth)
  db.collection("User").document(uid).setData([
      "nickname": "지훈",
      "email": "...",
      "coin": 100,
      "templates": [...],
      // 모든 유저 데이터
  ])
```

```
  // Auth는 인증만 담당하게 되어잇음.
  Auth.auth().currentUser?.uid  // 단지 uid만 제공
```

## 📱 스크린샷 (UI 변경 시)
### 기존에 로그인 한 상태로 접속해서 얻은 필드
<img width="374" alt="image" src="https://github.com/user-attachments/assets/935215c6-00e5-4186-8271-d05a5f2bb180" />

### 신규 가입해도 잘 됨.
<img width="374" alt="image" src="https://github.com/user-attachments/assets/a8278238-b0e5-4ed6-8ebb-8a7014f55db9" />

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
