### PR TITLE
feat: 아이템 디테일 뷰를 위한 컴포넌트 분리 (from. TemplatePreview)

### DIFF
--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -45,9 +45,9 @@
 		4C6622442EAF77AB001760B5 /* NanumSquareRoundOTFR.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4C66223F2EAF77AB001760B5 /* NanumSquareRoundOTFR.otf */; };
 		4C6622462EAF7D63001760B5 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 4C6622452EAF7D63001760B5 /* LICENSE */; };
 		4C6622482EAF9B3A001760B5 /* Haptic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6622472EAF9B3A001760B5 /* Haptic.swift */; };
-		4C7775322EB0EEF100981C3E /* PreviewImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7775312EB0EEF100981C3E /* PreviewImage.swift */; };
-		4C7775342EB0EF8800981C3E /* PreviewInfoSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7775332EB0EF8800981C3E /* PreviewInfoSection.swift */; };
-		4C7775382EB0EFD800981C3E /* PreviewMakingBtn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7775372EB0EFD800981C3E /* PreviewMakingBtn.swift */; };
+		4C7775322EB0EEF100981C3E /* ItemDetailImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7775312EB0EEF100981C3E /* ItemDetailImage.swift */; };
+		4C7775342EB0EF8800981C3E /* ItemDetailInfoSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7775332EB0EF8800981C3E /* ItemDetailInfoSection.swift */; };
+		4C7775382EB0EFD800981C3E /* ItemDetailMakingBtn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7775372EB0EFD800981C3E /* ItemDetailMakingBtn.swift */; };
 		4C77753E2EB1343600981C3E /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7775392EB1343600981C3E /* IntroViewModel.swift */; };
 		4C77753F2EB1343600981C3E /* IntroViewModel+Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C77753A2EB1343600981C3E /* IntroViewModel+Login.swift */; };
 		4C7775402EB1343600981C3E /* IntroViewModel+Signup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C77753C2EB1343600981C3E /* IntroViewModel+Signup.swift */; };
@@ -197,9 +197,9 @@
 		4C66223F2EAF77AB001760B5 /* NanumSquareRoundOTFR.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = NanumSquareRoundOTFR.otf; sourceTree = "<group>"; };
 		4C6622452EAF7D63001760B5 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		4C6622472EAF9B3A001760B5 /* Haptic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptic.swift; sourceTree = "<group>"; };
-		4C7775312EB0EEF100981C3E /* PreviewImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewImage.swift; sourceTree = "<group>"; };
-		4C7775332EB0EF8800981C3E /* PreviewInfoSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewInfoSection.swift; sourceTree = "<group>"; };
-		4C7775372EB0EFD800981C3E /* PreviewMakingBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewMakingBtn.swift; sourceTree = "<group>"; };
+		4C7775312EB0EEF100981C3E /* ItemDetailImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailImage.swift; sourceTree = "<group>"; };
+		4C7775332EB0EF8800981C3E /* ItemDetailInfoSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailInfoSection.swift; sourceTree = "<group>"; };
+		4C7775372EB0EFD800981C3E /* ItemDetailMakingBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailMakingBtn.swift; sourceTree = "<group>"; };
 		4C7775392EB1343600981C3E /* IntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModel.swift; sourceTree = "<group>"; };
 		4C77753A2EB1343600981C3E /* IntroViewModel+Login.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntroViewModel+Login.swift"; sourceTree = "<group>"; };
 		4C77753B2EB1343600981C3E /* IntroViewModel+NicknameSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntroViewModel+NicknameSetup.swift"; sourceTree = "<group>"; };
@@ -413,9 +413,6 @@
 			isa = PBXGroup;
 			children = (
 				4CBBEF1D2EB260BE00252590 /* CameraPicker.swift */,
-				4C7775312EB0EEF100981C3E /* PreviewImage.swift */,
-				4C7775332EB0EF8800981C3E /* PreviewInfoSection.swift */,
-				4C7775372EB0EFD800981C3E /* PreviewMakingBtn.swift */,
 				4CB82ECA2EB1FD8500B7458B /* PreviewGuiding.swift */,
 			);
 			path = Components;
@@ -430,6 +427,16 @@
 				4C77753C2EB1343600981C3E /* IntroViewModel+Signup.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		4CBBEF202EB3705E00252590 /* Items */ = {
+			isa = PBXGroup;
+			children = (
+				4C7775312EB0EEF100981C3E /* ItemDetailImage.swift */,
+				4C7775332EB0EF8800981C3E /* ItemDetailInfoSection.swift */,
+				4C7775372EB0EFD800981C3E /* ItemDetailMakingBtn.swift */,
+			);
+			path = Items;
 			sourceTree = "<group>";
 		};
 		4CEC61A82EAE071B0099ECEE = {
@@ -532,6 +539,7 @@
 		4CEC61F82EAE08DA0099ECEE /* View */ = {
 			isa = PBXGroup;
 			children = (
+				4CBBEF202EB3705E00252590 /* Items */,
 				38C147B92EB13B2100A8E511 /* Button */,
 				4CEC62A62EAE0C130099ECEE /* LottieView.swift */,
 				AA9B2E902EB081750004D31C /* ItemDetailView.swift */,
@@ -1105,7 +1113,7 @@
 				4CEC62212EAE08DA0099ECEE /* UIImage+Extension.swift in Sources */,
 				4CEC62222EAE08DA0099ECEE /* CollectionRoute.swift in Sources */,
 				4CEC62232EAE08DA0099ECEE /* KeyringRingComponent.swift in Sources */,
-				4C7775342EB0EF8800981C3E /* PreviewInfoSection.swift in Sources */,
+				4C7775342EB0EF8800981C3E /* ItemDetailInfoSection.swift in Sources */,
 				4CEC62A52EAE0BA30099ECEE /* CollectionViewModel+Bundle.swift in Sources */,
 				4CEC62252EAE08DA0099ECEE /* WorkshopRoute.swift in Sources */,
 				4CEC62262EAE08DA0099ECEE /* Radius.swift in Sources */,
@@ -1121,7 +1129,7 @@
 				4CEC626B2EAE08DF0099ECEE /* FestivalTab.swift in Sources */,
 				4CEC626C2EAE08DF0099ECEE /* FestivalView.swift in Sources */,
 				4CEC626D2EAE08DF0099ECEE /* WorkshopTab.swift in Sources */,
-				4C7775382EB0EFD800981C3E /* PreviewMakingBtn.swift in Sources */,
+				4C7775382EB0EFD800981C3E /* ItemDetailMakingBtn.swift in Sources */,
 				4CBBEF1E2EB260BE00252590 /* CameraPicker.swift in Sources */,
 				4CEC626E2EAE08DF0099ECEE /* AcrylicPhotoCropView.swift in Sources */,
 				4CB82EC92EB1EDB700B7458B /* AcrylicPhotoVM+BGRemover.swift in Sources */,
@@ -1144,7 +1152,7 @@
 				C665DDE82EAEFA8700CE4495 /* CoinChargeView.swift in Sources */,
 				4CEC629E2EAE09990099ECEE /* BundleCreateView.swift in Sources */,
 				C6C4029F2EB30163006B58DF /* WorkshopViewModel.swift in Sources */,
-				4C7775322EB0EEF100981C3E /* PreviewImage.swift in Sources */,
+				4C7775322EB0EEF100981C3E /* ItemDetailImage.swift in Sources */,
 				38C147BB2EB13B2F00A8E511 /* CircleGlassButton.swift in Sources */,
 				38C147C72EB1F57F00A8E511 /* StorageManager.swift in Sources */,
 				4CEC629F2EAE09990099ECEE /* BundleDetailView.swift in Sources */,

--- a/Keychy/Keychy/CommonModels/KeyringBundle/Background.swift
+++ b/Keychy/Keychy/CommonModels/KeyringBundle/Background.swift
@@ -16,7 +16,10 @@ struct Background: Identifiable, Codable, Equatable, Hashable {
     
     /// 배경 이름
     let backgroundName: String
-    
+
+    /// 배경 설명
+    let description: String
+
     /// 배경 이미지 URL (썸네일 공통)
     let backgroundImage: String
     

--- a/Keychy/Keychy/Core/Components/View/Items/ItemDetailImage.swift
+++ b/Keychy/Keychy/Core/Components/View/Items/ItemDetailImage.swift
@@ -1,5 +1,5 @@
 //
-//  TemplatePreviewImage.swift
+//  TemplateItemDetailImage.swift
 //  Keychy
 //
 //  Created by 길지훈 on 10/28/25.
@@ -8,13 +8,13 @@
 import SwiftUI
 import NukeUI
 
-struct PreviewImage: View {
+struct ItemDetailImage: View {
     
-    /// 파이어 스토어에서 가져올 프리뷰이미지
-    let previewURL: String
+    /// 파이어 스토어에서 가져올 item이미지
+    let itemURL: String
     
     var body: some View {
-        LazyImage(url: URL(string: previewURL)) { state in
+        LazyImage(url: URL(string: itemURL)) { state in
             if let image = state.image {
                 image
                     .resizable()
@@ -29,5 +29,5 @@ struct PreviewImage: View {
 }
 
 #Preview(traits: .sizeThatFitsLayout) {
-    PreviewImage(previewURL: "https://firebasestorage.googleapis.com/v0/b/keychy-f6011.firebasestorage.app/o/Templates%2FacrylicPhoto%2FacrylicPreview.png?alt=media&token=cc1e53cf-9de2-4a32-a50f-f02339999f24")
+    ItemDetailImage(itemURL: "https://firebasestorage.googleapis.com/v0/b/keychy-f6011.firebasestorage.app/o/Templates%2FacrylicPhoto%2FacrylicPreview.png?alt=media&token=cc1e53cf-9de2-4a32-a50f-f02339999f24")
 }

--- a/Keychy/Keychy/Core/Components/View/Items/ItemDetailInfoSection.swift
+++ b/Keychy/Keychy/Core/Components/View/Items/ItemDetailInfoSection.swift
@@ -7,8 +7,8 @@
 
 import SwiftUI
 
-struct PreviewInfoSection: View {
-    let template: KeyringTemplate
+struct ItemDetailInfoSection: View {
+    let item: any WorkshopItem
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -16,19 +16,19 @@ struct PreviewInfoSection: View {
             /// 태그들
             HStack(spacing: 8) {
                 /// 유료 태그 표시
-                if !template.isFree {
-                    templatePaidTag
+                if !item.isFree {
+                    itemPaidTag
                 }
-                templateTags
+                itemTags
             }
             .padding(.bottom, 4)
 
-            /// 템플릿 이름
-            templateName
+            /// item 이름
+            itemName
                 .padding(.bottom, 12)
             
-            /// 템플릿 설명
-            templateDescription
+            /// item 설명
+            itemDescription
         }
     }
 
@@ -36,10 +36,10 @@ struct PreviewInfoSection: View {
 }
 
 // MARK: - Components
-extension PreviewInfoSection {
-    private var templateTags: some View {
+extension ItemDetailInfoSection {
+    private var itemTags: some View {
         HStack(spacing: 8) {
-            if template.tags.isEmpty {
+            if item.tags.isEmpty {
                 Text("지정된 태그가 없습니다.")
                     .typography(.suit14M)
                     .foregroundStyle(.gray500)
@@ -50,7 +50,7 @@ extension PreviewInfoSection {
                     .clipShape(.rect)
                     .cornerRadius(10)
             } else {
-                ForEach(template.tags, id: \.self) { tag in
+                ForEach(item.tags, id: \.self) { tag in
                     Text(tag)
                         .typography(.suit14M)
                         .foregroundStyle(.gray500)
@@ -65,24 +65,24 @@ extension PreviewInfoSection {
         }
     }
 
-    private var templatePaidTag: some View {
+    private var itemPaidTag: some View {
         Image("PaidTestIcon")
     }
 
-    private var templateName: some View {
-        Text(template.templateName)
+    private var itemName: some View {
+        Text(item.name)
             .typography(.suit24B)
     }
 
-    private var templateDescription: some View {
-        Text(template.description)
+    private var itemDescription: some View {
+        Text(item.itemDescription)
             .typography(.suit15R)
             .foregroundStyle(.gray500)
     }
 }
 
 #Preview(traits: .sizeThatFitsLayout) {
-    PreviewInfoSection(template: .acrylicPhoto)
+    ItemDetailInfoSection(item: KeyringTemplate.acrylicPhoto)
 }
 
 

--- a/Keychy/Keychy/Core/Components/View/Items/ItemDetailMakingBtn.swift
+++ b/Keychy/Keychy/Core/Components/View/Items/ItemDetailMakingBtn.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct PreviewMakingBtn: View {
+struct ItemDetailMakingBtn: View {
     let title: String
     
     // 클로저로 액션 전달 받기
@@ -26,5 +26,5 @@ struct PreviewMakingBtn: View {
 }
 
 #Preview(traits: .sizeThatFitsLayout) {
-    PreviewMakingBtn(title: "예시버튼", action: { print("예시동작") })
+    ItemDetailMakingBtn(title: "예시버튼", action: { print("예시동작") })
 }

--- a/Keychy/Keychy/Features/Collection/CollectionViewModel.swift
+++ b/Keychy/Keychy/Features/Collection/CollectionViewModel.swift
@@ -68,6 +68,7 @@ class CollectionViewModel {
         Background(
             id: "12347",
             backgroundName: "기본 배경 A",
+            description: "무료로 제공되는 기본 배경화면",
             backgroundImage: "ddochi",
             tags: ["tag1"],
             price: 0,
@@ -78,6 +79,7 @@ class CollectionViewModel {
         Background(
             id: "12346",
             backgroundName: "기본 배경 B",
+            description: "심플하고 깔끔한 기본 배경",
             backgroundImage: "Cherries",
             tags: ["tag1"],
             price: 0,
@@ -88,6 +90,7 @@ class CollectionViewModel {
         Background(
             id: "12341",
             backgroundName: "유료 배경 A",
+            description: "화려한 프리미엄 배경화면",
             backgroundImage: "fireworks",
             tags: ["tag1"],
             price: 100,
@@ -98,6 +101,7 @@ class CollectionViewModel {
         Background(
             id: "12342",
             backgroundName: "유료 배경 B",
+            description: "특별한 프리미엄 테마 배경",
             backgroundImage: "ddochi",
             tags: ["tag1"],
             price: 100,
@@ -112,9 +116,9 @@ class CollectionViewModel {
     var carabiners: [Carabiner] = [
         Carabiner(
             id: "12343",
-            carabinerName: "카라비너 이름",
+            carabinerName: "카라비너 A",
             carabinerImage: "ddochi",
-            description: "",
+            description: "기본 스타일의 실버 카라비너",
             maxKeyringCount: 4,
             tags: ["tags"],
             price: 0,
@@ -126,9 +130,9 @@ class CollectionViewModel {
         ),
         Carabiner(
             id: "12344",
-            carabinerName: "카라비너 이름",
+            carabinerName: "카라비너 B",
             carabinerImage: "ddochi",
-            description: "",
+            description: "세련된 골드 카라비너",
             maxKeyringCount: 4,
             tags: ["tags"],
             price: 0,
@@ -140,9 +144,9 @@ class CollectionViewModel {
         ),
         Carabiner(
             id: "12345",
-            carabinerName: "카라비너 이름",
+            carabinerName: "카라비너 C",
             carabinerImage: "ddochi",
-            description: "",
+            description: "모던한 블랙 카라비너",
             maxKeyringCount: 4,
             tags: ["tags"],
             price: 0,

--- a/Keychy/Keychy/Features/Workshop/Making/Templates/AcrylicPhoto/Views/AcrylicPhotoPreView.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Templates/AcrylicPhoto/Views/AcrylicPhotoPreView.swift
@@ -93,8 +93,8 @@ struct AcrylicPhotoPreView: View {
 // MARK: - KeyringScene Section
 extension AcrylicPhotoPreView {
     private var keyringPreivew: some View {
-        PreviewImage(
-            previewURL: viewModel.template?.previewURL ?? "")
+        ItemDetailImage(
+            itemURL: viewModel.template?.previewURL ?? "")
             .scaledToFit()
             .frame(maxWidth: .infinity)
     }
@@ -105,7 +105,7 @@ extension AcrylicPhotoPreView {
     @ViewBuilder
     private func keyringInfo(template: KeyringTemplate?) -> some View {
         if let template {
-            PreviewInfoSection(template: template)
+            ItemDetailInfoSection(item: template)
         } else {
             Text("템플릿 정보 없음")
         }
@@ -114,7 +114,7 @@ extension AcrylicPhotoPreView {
 
 extension AcrylicPhotoPreView {
     private var makeBtn: some View {
-        PreviewMakingBtn(title: "만들기") {
+        ItemDetailMakingBtn(title: "만들기") {
             showGuide = true
             selectedItem = nil
         }

--- a/Keychy/Keychy/Features/Workshop/WorkshopView.swift
+++ b/Keychy/Keychy/Features/Workshop/WorkshopView.swift
@@ -41,7 +41,6 @@ struct WorkshopView: View {
             sortSheet
         }
         .task {
-            // Environment의 실제 UserManager로 ViewModel 교체
             viewModel = WorkshopViewModel(userManager: userManager)
             await viewModel.fetchAllData()
             await viewModel.loadOwnedItems()

--- a/Keychy/Keychy/Features/Workshop/WorkshopViewModel.swift
+++ b/Keychy/Keychy/Features/Workshop/WorkshopViewModel.swift
@@ -28,6 +28,7 @@ enum CommonFilterType: String, CaseIterable {
 protocol WorkshopItem: Identifiable, Decodable {
     var id: String? { get }
     var name: String { get }
+    var itemDescription: String { get }
     var thumbnailURL: String { get }
     var isFree: Bool { get }
     var workshopPrice: Int { get }
@@ -40,29 +41,34 @@ protocol WorkshopItem: Identifiable, Decodable {
 
 extension KeyringTemplate: WorkshopItem {
     var name: String { templateName }
+    var itemDescription: String { description }
     var workshopPrice: Int { price ?? 0 }
 }
 
 extension Background: WorkshopItem {
     var name: String { backgroundName }
+    var itemDescription: String { description }
     var thumbnailURL: String { backgroundImage }
     var workshopPrice: Int { price }
 }
 
 extension Carabiner: WorkshopItem {
     var name: String { carabinerName }
+    var itemDescription: String { description }
     var thumbnailURL: String { carabinerImage }
     var workshopPrice: Int { price }
 }
 
 extension Particle: WorkshopItem {
     var name: String { particleName }
+    var itemDescription: String { description }
     var thumbnailURL: String { thumbnail }
     var workshopPrice: Int { price }
 }
 
 extension Sound: WorkshopItem {
     var name: String { soundName }
+    var itemDescription: String { description }
     var thumbnailURL: String { thumbnail }
     var workshopPrice: Int { price }
 }


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

아이템 디테일뷰는 템플릿, 카라비너, 이펙트 등 다양한 요소에서 꼭 들어간 뷰입니다.
해당 뷰에서 사용되는 컴포넌트를 기존 preview를 설계해둔 코드에서 분리했습니다.

@heondolee 런도가 공방, 창고를 맡고있어서 1순위 참고자이지만 
다른분들도 참고해주세요. 

아이템 대상이 되는 모델들에 "description" 필드가 추가됐어요.



## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
