### PR TITLE
fix: workshop뷰 진입시 초기 렌더링 에러 수정

### DIFF
--- a/Keychy/Keychy/Features/Workshop/WorkshopView.swift
+++ b/Keychy/Keychy/Features/Workshop/WorkshopView.swift
@@ -323,7 +323,7 @@ extension WorkshopView {
                 .foregroundColor(.secondary)
             Spacer()
         }
-        .frame(width: 345, height: 112)
+        .frame(width: 343, height: 112)
         .background(Color.white.opacity(0.4))
         .cornerRadius(10)
     }
@@ -336,7 +336,7 @@ extension WorkshopView {
                 .progressViewStyle(CircularProgressViewStyle(tint: .purple))
             Spacer()
         }
-        .frame(width: 345, height: 113)
+        .frame(width: 343, height: 113)
     }
 
 }


### PR DESCRIPTION
## 🎯 PR 내용
- fix: workshop뷰 진입시 초기 UI렌더링 깨짐을 수정했습니다.
- 내 창고가 비었어요 박스를 추가했습니다.

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->
<img width="200" alt="image" src="https://github.com/user-attachments/assets/ae9d9679-df95-4106-b366-a153b75b0480" />

## 🔗 관련 이슈
- scrollview 위치를 일고 sticky categorybar가 위치를 찾아가는데, 초기에 살짝 스크롤 자극을 주면 제자리를 찾아가는거 보고 일단 아주 살짝 흔들리게 해서 해결했습니다. 나중에 안흔들리고 안깨지도록 개선할게요

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
