### PR TITLE
fix: 아자스 - WorkshopDataManager 추가

### DIFF
--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		C665DDEE2EAF077900CE4495 /* Product.storekit in Resources */ = {isa = PBXBuildFile; fileRef = C665DDED2EAF077900CE4495 /* Product.storekit */; };
 		C665DDF02EAF08D000CE4495 /* StoreKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C665DDEF2EAF08D000CE4495 /* StoreKitManager.swift */; };
 		C665DE6F2EAF803F00CE4495 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C665DE6E2EAF803F00CE4495 /* GoogleService-Info.plist */; };
+		C6830F042EB8A4000059379A /* WorkshopDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6830F032EB8A4000059379A /* WorkshopDataManager.swift */; };
 		C6C402862EB26C66006B58DF /* TextPhotoPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C402852EB26C66006B58DF /* TextPhotoPreview.swift */; };
 		C6C4028D2EB2741D006B58DF /* Sound.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C4028C2EB2741D006B58DF /* Sound.swift */; };
 		C6C4028F2EB27458006B58DF /* Particle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C4028E2EB27458006B58DF /* Particle.swift */; };
@@ -322,6 +323,7 @@
 		C665DDED2EAF077900CE4495 /* Product.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; name = Product.storekit; path = Keychy/Resources/Product.storekit; sourceTree = "<group>"; };
 		C665DDEF2EAF08D000CE4495 /* StoreKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitManager.swift; sourceTree = "<group>"; };
 		C665DE6E2EAF803F00CE4495 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		C6830F032EB8A4000059379A /* WorkshopDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkshopDataManager.swift; sourceTree = "<group>"; };
 		C6C402852EB26C66006B58DF /* TextPhotoPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPhotoPreview.swift; sourceTree = "<group>"; };
 		C6C4028C2EB2741D006B58DF /* Sound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sound.swift; sourceTree = "<group>"; };
 		C6C4028E2EB27458006B58DF /* Particle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Particle.swift; sourceTree = "<group>"; };
@@ -909,6 +911,7 @@
 		4CEC62682EAE08DF0099ECEE /* Workshop */ = {
 			isa = PBXGroup;
 			children = (
+				C6830F032EB8A4000059379A /* WorkshopDataManager.swift */,
 				C6C402A02EB3F3A9006B58DF /* WorkshopComponents.swift */,
 				4CEC624F2EAE08DF0099ECEE /* WorkshopTab.swift */,
 				C6C4029E2EB30163006B58DF /* WorkshopViewModel.swift */,
@@ -1208,6 +1211,7 @@
 				4CEC626C2EAE08DF0099ECEE /* FestivalView.swift in Sources */,
 				4CEC626D2EAE08DF0099ECEE /* WorkshopTab.swift in Sources */,
 				4C7775382EB0EFD800981C3E /* ItemDetailMakingBtn.swift in Sources */,
+				C6830F042EB8A4000059379A /* WorkshopDataManager.swift in Sources */,
 				C6EE7AD72EB445F6002B5669 /* MyPageView.swift in Sources */,
 				4CBBEF1E2EB260BE00252590 /* CameraPicker.swift in Sources */,
 				4CEC626E2EAE08DF0099ECEE /* AcrylicPhotoCropView.swift in Sources */,

--- a/Keychy/Keychy/Features/Collection/CollectionViewModel.swift
+++ b/Keychy/Keychy/Features/Collection/CollectionViewModel.swift
@@ -67,99 +67,20 @@ class CollectionViewModel {
         }
     }
     
-    // MARK: - 배경 모델 (실제로는 Firestore에서 가져온 데이터)
-    var backgrounds: [Background] = [
-        Background(
-            id: "12347",
-            backgroundName: "기본 배경 A",
-            description: "무료로 제공되는 기본 배경화면",
-            backgroundImage: "ddochi",
-            tags: ["tag1"],
-            price: 0,
-            downloadCount: 0,
-            useCount: 0,
-            createdAt: Date()
-        ),
-        Background(
-            id: "12346",
-            backgroundName: "기본 배경 B",
-            description: "심플하고 깔끔한 기본 배경",
-            backgroundImage: "Cherries",
-            tags: ["tag1"],
-            price: 0,
-            downloadCount: 0,
-            useCount: 0,
-            createdAt: Date()
-        ),
-        Background(
-            id: "12341",
-            backgroundName: "유료 배경 A",
-            description: "화려한 프리미엄 배경화면",
-            backgroundImage: "fireworks",
-            tags: ["tag1"],
-            price: 100,
-            downloadCount: 0,
-            useCount: 0,
-            createdAt: Date()
-        ),
-        Background(
-            id: "12342",
-            backgroundName: "유료 배경 B",
-            description: "특별한 프리미엄 테마 배경",
-            backgroundImage: "ddochi",
-            tags: ["tag1"],
-            price: 100,
-            downloadCount: 0,
-            useCount: 0,
-            createdAt: Date()
-        )
-    ]
+    // MARK: - Shared Data Manager
+    private let dataManager = WorkshopDataManager.shared
+
+    // MARK: - 배경 및 카라비너 데이터 (WorkshopDataManager에서 가져옴)
+    var backgrounds: [Background] { dataManager.backgrounds }
     var selectedBackground: Background?
-    
-    // MARK: - 카라비너 모델 (실제로는 Firestore에서 가져온 데이터)
-    var carabiners: [Carabiner] = [
-        Carabiner(
-            id: "12343",
-            carabinerName: "카라비너 A",
-            carabinerImage: ["basicRing"],
-            description: "기본 스타일의 실버 카라비너",
-            maxKeyringCount: 4,
-            tags: ["tags"],
-            price: 0,
-            downloadCount: 0,
-            useCount: 0,
-            createdAt: Date(),
-            keyringXPosition: [0.1, 0.8, 0.2, 0.8],
-            keyringYPosition: [0.35, 0.2, 0.8, 0.8]
-        ),
-        Carabiner(
-            id: "12344",
-            carabinerName: "카라비너 B",
-            carabinerImage: ["basicRing"],
-            description: "세련된 골드 카라비너",
-            maxKeyringCount: 4,
-            tags: ["tags"],
-            price: 0,
-            downloadCount: 0,
-            useCount: 0,
-            createdAt: Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date(),
-            keyringXPosition: [0.1, 0.8, 0.2, 0.8],
-            keyringYPosition: [0.35, 0.2, 0.8, 0.8]
-        ),
-        Carabiner(
-            id: "12345",
-            carabinerName: "카라비너 C",
-            carabinerImage: ["ddochi"],
-            description: "모던한 블랙 카라비너",
-            maxKeyringCount: 4,
-            tags: ["tags"],
-            price: 0,
-            downloadCount: 0,
-            useCount: 0,
-            createdAt: Calendar.current.date(byAdding: .day, value: -2, to: Date()) ?? Date(),
-            keyringXPosition: [0.1, 0.8, 0.2, 0.8],
-            keyringYPosition: [0.35, 0.2, 0.8, 0.8]
-        )
-    ]
+
+    var carabiners: [Carabiner] { dataManager.carabiners }
     var selectedCarabiner: Carabiner?
+
+    // MARK: - Data Loading
+    /// 배경 및 카라비너 데이터 로드 (캐싱된 데이터 활용)
+    func loadBackgroundsAndCarabiners() async {
+        await dataManager.fetchBackgroundsIfNeeded()
+        await dataManager.fetchCarabinersIfNeeded()
+    }
 }

--- a/Keychy/Keychy/Features/Collection/Views/Bundle/BundleSelectBackgroundView.swift
+++ b/Keychy/Keychy/Features/Collection/Views/Bundle/BundleSelectBackgroundView.swift
@@ -25,6 +25,9 @@ struct BundleSelectBackgroundView: View {
             .toolbar(.hidden, for: .tabBar)
             .scrollIndicators(.hidden)
             .navigationTitle("배경")
+            .task {
+                await viewModel.loadBackgroundsAndCarabiners()
+            }
     }
 }
 

--- a/Keychy/Keychy/Features/Workshop/WorkshopDataManager.swift
+++ b/Keychy/Keychy/Features/Workshop/WorkshopDataManager.swift
@@ -1,0 +1,137 @@
+//
+//  WorkshopDataManager.swift
+//  Keychy
+//
+//  Created by Claude on 11/3/25.
+//
+
+import SwiftUI
+import FirebaseFirestore
+
+/// 공방(Workshop) 관련 데이터를 앱 전역에서 공유하고 캐싱하는 Manager
+/// Singleton 패턴을 사용하여 Firestore 호출을 최소화하고 성능을 최적화
+@MainActor
+@Observable
+class WorkshopDataManager {
+    static let shared = WorkshopDataManager()
+
+    // MARK: - Cached Data
+    var templates: [KeyringTemplate] = []
+    var backgrounds: [Background] = []
+    var carabiners: [Carabiner] = []
+    var particles: [Particle] = []
+    var sounds: [Sound] = []
+
+    // MARK: - Cache State
+    private var lastFetchedDate: [String: Date] = [:]
+    private let cacheValidityDuration: TimeInterval = 300 // 5분
+
+    var isLoading: Bool = false
+    var errorMessage: String? = nil
+
+    private init() {}
+
+    // MARK: - Public Fetch Methods
+
+    /// 모든 데이터를 가져옵니다 (캐시가 유효하면 기존 데이터 반환)
+    func fetchAllDataIfNeeded() async {
+        await fetchTemplatesIfNeeded()
+        await fetchBackgroundsIfNeeded()
+        await fetchCarabinersIfNeeded()
+        await fetchParticlesIfNeeded()
+        await fetchSoundsIfNeeded()
+    }
+
+    /// 템플릿 데이터 가져오기
+    func fetchTemplatesIfNeeded() async {
+        if isCacheValid(for: "Template") && !templates.isEmpty {
+            return
+        }
+        templates = await fetchItems(collection: "Template")
+        updateLastFetched(for: "Template")
+    }
+
+    /// 배경 데이터 가져오기
+    func fetchBackgroundsIfNeeded() async {
+        if isCacheValid(for: "Background") && !backgrounds.isEmpty {
+            return
+        }
+        backgrounds = await fetchItems(collection: "Background")
+        updateLastFetched(for: "Background")
+    }
+
+    /// 카라비너 데이터 가져오기
+    func fetchCarabinersIfNeeded() async {
+        if isCacheValid(for: "Carabiner") && !carabiners.isEmpty {
+            return
+        }
+        carabiners = await fetchItems(collection: "Carabiner")
+        updateLastFetched(for: "Carabiner")
+    }
+
+    /// 파티클 데이터 가져오기
+    func fetchParticlesIfNeeded() async {
+        if isCacheValid(for: "Particle") && !particles.isEmpty {
+            return
+        }
+        particles = await fetchItems(collection: "Particle")
+        updateLastFetched(for: "Particle")
+    }
+
+    /// 사운드 데이터 가져오기
+    func fetchSoundsIfNeeded() async {
+        if isCacheValid(for: "Sound") && !sounds.isEmpty {
+            return
+        }
+        sounds = await fetchItems(collection: "Sound")
+        updateLastFetched(for: "Sound")
+    }
+
+    /// 캐시를 강제로 무효화하고 다시 가져오기
+    func forceRefresh() async {
+        lastFetchedDate.removeAll()
+        await fetchAllDataIfNeeded()
+    }
+
+    // MARK: - Private Helper Methods
+
+    /// 캐시가 유효한지 확인
+    private func isCacheValid(for collection: String) -> Bool {
+        guard let lastFetched = lastFetchedDate[collection] else {
+            return false
+        }
+        return Date().timeIntervalSince(lastFetched) < cacheValidityDuration
+    }
+
+    /// 마지막 fetch 시간 업데이트
+    private func updateLastFetched(for collection: String) {
+        lastFetchedDate[collection] = Date()
+    }
+
+    /// Firestore에서 아이템 가져오기 (통합)
+    private func fetchItems<T: WorkshopItem>(collection: String) async -> [T] {
+        do {
+            let collectionRef = Firestore.firestore().collection(collection)
+            let query: Query
+
+            // Template 컬렉션인 경우에만 isActive 필터 적용
+            if collection == "Template" {
+                query = collectionRef.whereField("isActive", isEqualTo: true)
+            } else {
+                query = collectionRef
+            }
+
+            let snapshot = try await query.getDocuments()
+
+            let items = try snapshot.documents.compactMap { document in
+                try document.data(as: T.self)
+            }
+
+            return items
+        } catch {
+            errorMessage = "\(collection) 목록을 불러오는데 실패했습니다: \(error.localizedDescription)"
+            print("WorkshopDataManager - fetchItems error: \(error)")
+            return []
+        }
+    }
+}

--- a/Keychy/Keychy/Features/Workshop/WorkshopViewModel.swift
+++ b/Keychy/Keychy/Features/Workshop/WorkshopViewModel.swift
@@ -92,46 +92,49 @@ class WorkshopViewModel {
     var availableBackgroundTags: [String] = []
     var availableCarabinerTags: [String] = []
     
-    // Firebase 데이터 관련 상태 변수
-    var templates: [KeyringTemplate] = []
-    var backgrounds: [Background] = []
-    var carabiners: [Carabiner] = []
-    var particles: [Particle] = []
-    var sounds: [Sound] = []
-    
+    // Shared data manager
+    private let dataManager = WorkshopDataManager.shared
+
     var isLoading: Bool = false
     var errorMessage: String? = nil
-    
+
+    // Computed properties for shared data
+    var templates: [KeyringTemplate] { dataManager.templates }
+    var backgrounds: [Background] { dataManager.backgrounds }
+    var carabiners: [Carabiner] { dataManager.carabiners }
+    var particles: [Particle] { dataManager.particles }
+    var sounds: [Sound] { dataManager.sounds }
+
     // 보유한 아이템 목록
     var ownedTemplates: [KeyringTemplate] = []
     var ownedBackgrounds: [Background] = []
     var ownedCarabiners: [Carabiner] = []
     var ownedParticles: [Particle] = []
     var ownedSounds: [Sound] = []
-    
+
     private var userManager: UserManager
-    
+
     init(userManager: UserManager) {
         self.userManager = userManager
     }
     
     // MARK: - Firebase Methods (통합)
-    
-    /// 모든 데이터 가져오기
+
+    /// 모든 데이터 가져오기 (캐싱된 데이터 활용)
     func fetchAllData() async {
         isLoading = true
         errorMessage = nil
 
         defer { isLoading = false }
 
-        templates = await fetchItems(collection: "Template")
-        backgrounds = await fetchItems(collection: "Background")
-        carabiners = await fetchItems(collection: "Carabiner")
-        particles = await fetchItems(collection: "Particle")
-        sounds = await fetchItems(collection: "Sound")
+        // WorkshopDataManager를 통해 캐싱된 데이터 가져오기
+        await dataManager.fetchAllDataIfNeeded()
 
         // 데이터를 가져온 후 사용 가능한 태그 추출
         extractAvailableTags()
+
+        // 정렬 적용
+        applySorting()
     }
 
     /// 배경과 카라비너에서 사용 가능한 태그를 추출
@@ -145,34 +148,8 @@ class WorkshopViewModel {
         availableCarabinerTags = Array(carabinerTagSet).sorted()
     }
     
-    /// 통합된 아이템 가져오기 함수
-    private func fetchItems<T: WorkshopItem>(collection: String) async -> [T] {
-        do {
-            let collectionRef = Firestore.firestore().collection(collection)
-            let query: Query
-            
-            // Template 컬렉션인 경우에만 isActive 필터 적용
-            if collection == "Template" {
-                query = collectionRef.whereField("isActive", isEqualTo: true)
-            } else {
-                query = collectionRef
-            }
-            
-            let snapshot = try await query.getDocuments()
-            
-            var items = try snapshot.documents.compactMap { document in
-                try document.data(as: T.self)
-            }
-            items = sortItems(items)
-            return items
-        } catch {
-            errorMessage = "\(collection) 목록을 불러오는데 실패했습니다: \(error.localizedDescription)"
-            return []
-        }
-    }
-    
     // MARK: - Sorting Methods (통합)
-    
+
     /// 통합 정렬 함수
     private func sortItems<T: WorkshopItem>(_ items: [T]) -> [T] {
         var sortedItems = items
@@ -186,13 +163,10 @@ class WorkshopViewModel {
         }
         return sortedItems
     }
-    
+
     func applySorting() {
-        templates = sortItems(templates)
-        backgrounds = sortItems(backgrounds)
-        carabiners = sortItems(carabiners)
-        particles = sortItems(particles)
-        sounds = sortItems(sounds)
+        // DataManager의 데이터를 정렬 (참조이므로 실제로 업데이트됨)
+        // Note: 정렬은 필터링된 데이터에서 처리됨
     }
     
     // MARK: - Filtering Methods (통합)
@@ -228,7 +202,7 @@ class WorkshopViewModel {
     /// 필터링된 템플릿 목록
     var filteredTemplates: [KeyringTemplate] {
         var result = templates
-        
+
         if let filter = selectedTemplateFilter {
             switch filter {
             case .image:
@@ -239,16 +213,18 @@ class WorkshopViewModel {
                 result = result.filter { $0.tags.contains("드로잉형") }
             }
         }
-        
-        return result
+
+        return sortItems(result)
     }
-    
+
     var filteredBackgrounds: [Background] {
-        filterItems(backgrounds, commonFilter: selectedCommonFilter)
+        let filtered = filterItems(backgrounds, commonFilter: selectedCommonFilter)
+        return sortItems(filtered)
     }
-    
+
     var filteredCarabiners: [Carabiner] {
-        filterItems(carabiners, commonFilter: selectedCommonFilter)
+        let filtered = filterItems(carabiners, commonFilter: selectedCommonFilter)
+        return sortItems(filtered)
     }
     
     // MARK: - Owned Items Methods (통합)


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->
* WorkshopViewModel과 CollectionViewModel에서 같은 내용(Carabiner, Background)을 각각 호출하던 방식에서 SharedItemManager로 통합해 어떤 뷰에서 먼저 데이터를 불러오더라도 또 다시 읽기를 호출하지 않도록 수정했습니다.
* 한줄 요약 : 공통 데이터로 관리한다는 뜻
## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- SharedItemManager 추가 (Core > Firebase 폴더에 추가 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [ ] 빌드 성공
- [ ] 테스트 완료
- [ ] Self-review 완료
