### PR TITLE
feat: 공방뷰 구매로직 및 팝업 완성

### DIFF
--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		C6B56F182EBF28170049F969 /* NeonSignVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B56F162EBF28170049F969 /* NeonSignVM.swift */; };
 		C6B56F1A2EBF284F0049F969 /* TemplatePreviewComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B56F192EBF284F0049F969 /* TemplatePreviewComponents.swift */; };
 		C6B56F1C2EBF2A960049F969 /* NeonSignVM+Effect.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B56F1B2EBF2A960049F969 /* NeonSignVM+Effect.swift */; };
+		C6B56F202EBF72130049F969 /* ItemPurchaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B56F1F2EBF72130049F969 /* ItemPurchaseManager.swift */; };
 		C6C402862EB26C66006B58DF /* NeonSignPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C402852EB26C66006B58DF /* NeonSignPreview.swift */; };
 		C6C4028D2EB2741D006B58DF /* Sound.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C4028C2EB2741D006B58DF /* Sound.swift */; };
 		C6C4028F2EB27458006B58DF /* Particle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C4028E2EB27458006B58DF /* Particle.swift */; };
@@ -407,6 +408,7 @@
 		C6B56F162EBF28170049F969 /* NeonSignVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeonSignVM.swift; sourceTree = "<group>"; };
 		C6B56F192EBF284F0049F969 /* TemplatePreviewComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplatePreviewComponents.swift; sourceTree = "<group>"; };
 		C6B56F1B2EBF2A960049F969 /* NeonSignVM+Effect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NeonSignVM+Effect.swift"; sourceTree = "<group>"; };
+		C6B56F1F2EBF72130049F969 /* ItemPurchaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemPurchaseManager.swift; sourceTree = "<group>"; };
 		C6C402852EB26C66006B58DF /* NeonSignPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeonSignPreview.swift; sourceTree = "<group>"; };
 		C6C4028C2EB2741D006B58DF /* Sound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sound.swift; sourceTree = "<group>"; };
 		C6C4028E2EB27458006B58DF /* Particle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Particle.swift; sourceTree = "<group>"; };
@@ -461,6 +463,7 @@
 		385425C42EB2C49700A06C02 /* Firebase */ = {
 			isa = PBXGroup;
 			children = (
+				C6B56F1F2EBF72130049F969 /* ItemPurchaseManager.swift */,
 				38A5967F2EAFCF5F0003D712 /* UserManager.swift */,
 				38C147C62EB1F57F00A8E511 /* StorageManager.swift */,
 				C645AEA22EB1B8FC004BFE69 /* TemplateInitializer.swift */,
@@ -1373,6 +1376,7 @@
 				C68931CE2EB7B94B00C5F083 /* EffectManager.swift in Sources */,
 				4CEC62232EAE08DA0099ECEE /* KeyringRingComponent.swift in Sources */,
 				4CBBEF242EB78A5D00252590 /* KeyringInfoInputView+Sheet.swift in Sources */,
+				C6B56F202EBF72130049F969 /* ItemPurchaseManager.swift in Sources */,
 				4CBBEF252EB78A5D00252590 /* KeyringInfoInputView+TagManagement.swift in Sources */,
 				4CBBEF262EB78A5D00252590 /* KeyringInfoInputView+Helpers.swift in Sources */,
 				4C7775342EB0EF8800981C3E /* ItemDetailInfoSection.swift in Sources */,

--- a/Keychy/Keychy/Core/Components/View/Popup/PurchasePopup.swift
+++ b/Keychy/Keychy/Core/Components/View/Popup/PurchasePopup.swift
@@ -11,9 +11,10 @@ struct PurchasePopup: View {
     let title: String
     let myCoin: Int
     let price: Int
+    let scale: CGFloat
     let onConfirm: () -> Void
-    
-    
+
+
     var body: some View {
         VStack(spacing: 10) {
             // 제목
@@ -21,38 +22,48 @@ struct PurchasePopup: View {
                 .typography(.suit20B)
                 .foregroundColor(.black100)
                 .padding(.top, 8)
-            
+
             Text("구매하시겠어요?")
                 .typography(.suit17SB)
                 .padding(.bottom, 24)
-            
-            HStack(spacing: 6) {
-                Text("내 보유")
+
+            HStack(spacing: 4) {
+                Text("내 보유 :")
                     .typography(.suit15M25)
-                
+                    .foregroundColor(.black100)
+
                 Text("\(myCoin)")
                     .typography(.nanum16EB)
                     .foregroundColor(.main500)
             }
+            .padding(.bottom, 4)
 
             // 버튼
             Button(action: onConfirm) {
-                Text("준비중")
-                    .typography(.suit17B)
-                    .foregroundColor(.white100)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 48)
-                    .background(
-                        RoundedRectangle(cornerRadius: 100)
-                            .fill(.black80)
-                    )
+                HStack(spacing: 5) {
+                    Image("purchaseSheet")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 20, height: 20)
+
+                    Text("\(price)")
+                        .typography(.nanum18EB12)
+                }
+                .foregroundColor(.white100)
+                .frame(maxWidth: .infinity)
+                .frame(height: 48)
+                .background(
+                    RoundedRectangle(cornerRadius: 100)
+                        .fill(.black80)
+                )
             }
             .buttonStyle(.plain)
-            
+
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 14)
         .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 34))
         .frame(width: 300, height: 207)
+        .scaleEffect(scale)
     }
 }

--- a/Keychy/Keychy/Core/Firebase/ItemPurchaseManager.swift
+++ b/Keychy/Keychy/Core/Firebase/ItemPurchaseManager.swift
@@ -1,0 +1,116 @@
+//
+//  ItemPurchaseManager.swift
+//  Keychy
+//
+//  아이템 구매 처리 로직 (워크샵, 코인샵 등)
+//
+
+import Foundation
+import FirebaseFirestore
+
+// MARK: - Purchase Result
+enum PurchaseResult {
+    case success
+    case insufficientCoins
+    case failed(String)
+}
+
+enum ItemPurchaseError: Error {
+    case insufficientCoins
+    case userNotFound
+    case itemNotFound
+    case updateFailed
+
+    var localizedDescription: String {
+        switch self {
+        case .insufficientCoins:
+            return "코인이 부족합니다"
+        case .userNotFound:
+            return "사용자 정보를 찾을 수 없습니다"
+        case .itemNotFound:
+            return "아이템 정보를 찾을 수 없습니다"
+        case .updateFailed:
+            return "구매 처리 중 오류가 발생했습니다"
+        }
+    }
+}
+
+@MainActor
+class ItemPurchaseManager {
+    static let shared = ItemPurchaseManager()
+
+    private init() {}
+
+    /// 워크샵 아이템 구매 처리
+    /// - Parameters:
+    ///   - item: 구매할 아이템 (WorkshopItem 프로토콜 준수)
+    ///   - userManager: UserManager 인스턴스
+    /// - Returns: PurchaseResult (성공, 코인부족, 실패)
+    func purchaseWorkshopItem(_ item: any WorkshopItem, userManager: UserManager) async -> PurchaseResult {
+        // 1. 현재 유저 정보 확인
+        guard let userId = userManager.currentUser?.id,
+              let userCoins = userManager.currentUser?.coin,
+              let itemId = item.id else {
+            return .failed("사용자 정보를 찾을 수 없습니다")
+        }
+
+        // 2. 재화 충분한지 확인
+        guard userCoins >= item.workshopPrice else {
+            return .insufficientCoins
+        }
+
+        // 3. Firebase 업데이트
+        let db = Firestore.firestore()
+        let userRef = db.collection("User").document(userId)
+
+        do {
+            // 현재 문서 읽기
+            let snapshot = try await userRef.getDocument()
+
+            guard let data = snapshot.data() else {
+                return .failed("사용자 정보를 찾을 수 없습니다")
+            }
+
+            let currentCoin = data["coin"] as? Int ?? 0
+
+            // 재화 재확인
+            guard currentCoin >= item.workshopPrice else {
+                return .insufficientCoins
+            }
+
+            // 업데이트할 데이터 준비
+            var updateData: [String: Any] = [
+                "coin": currentCoin - item.workshopPrice
+            ]
+
+            // 아이템 타입에 따라 해당 필드에 추가
+            if item is KeyringTemplate {
+                updateData["templates"] = FieldValue.arrayUnion([itemId])
+            } else if item is Background {
+                updateData["backgrounds"] = FieldValue.arrayUnion([itemId])
+            } else if item is Carabiner {
+                updateData["carabiners"] = FieldValue.arrayUnion([itemId])
+            } else if item is Particle {
+                updateData["particleEffects"] = FieldValue.arrayUnion([itemId])
+            } else if item is Sound {
+                updateData["soundEffects"] = FieldValue.arrayUnion([itemId])
+            }
+
+            // Firebase 업데이트
+            try await userRef.updateData(updateData)
+
+            // 4. UserManager 데이터 갱신
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                userManager.loadUserInfo(uid: userId) { _ in
+                    continuation.resume()
+                }
+            }
+
+            return .success
+
+        } catch {
+            print("구매 실패 에러: \(error.localizedDescription)")
+            return .failed("구매 처리 중 오류가 발생했습니다")
+        }
+    }
+}

--- a/Keychy/Keychy/Features/Collection/Views/CollectionView.swift
+++ b/Keychy/Keychy/Features/Collection/Views/CollectionView.swift
@@ -17,6 +17,7 @@ struct CollectionView: View {
     @State private var showDeleteAlert: Bool = false
     @State private var showDeleteCompleteAlert: Bool = false
     @State private var showInvenExpandAlert: Bool = false // 추후 인벤토리 확장용
+    @State private var invenExpandAlertScale: CGFloat = 0.3
     @State private var renamingCategory: String = ""
     @State private var deletingCategory: String = ""
     @State private var newCategoryName: String = ""
@@ -175,15 +176,24 @@ struct CollectionView: View {
                     .ignoresSafeArea()
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        showInvenExpandAlert = false // dismiss용
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                            invenExpandAlertScale = 0.3
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                            showInvenExpandAlert = false
+                        }
                     }
-                
+
                 PurchasePopup(
                     title: "인벤토리 확장 [+100]",
                     myCoin: collectionViewModel.coin,
                     price: 100,
+                    scale: invenExpandAlertScale,
                     onConfirm: {
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                            invenExpandAlertScale = 0.3
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                             showInvenExpandAlert = false
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
@@ -191,6 +201,8 @@ struct CollectionView: View {
                         }
                     }
                 )
+                .padding(.horizontal, 40)
+                .padding(.bottom, 30)
                 .transition(.scale.combined(with: .opacity))
             }
             
@@ -436,8 +448,9 @@ extension CollectionView {
                 .padding(.trailing, 8)
 
             Button(action: {
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                    showInvenExpandAlert = true
+                showInvenExpandAlert = true
+                withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
+                    invenExpandAlertScale = 1.0
                 }
             }) {
                 Image("InvenPlus")

--- a/Keychy/Keychy/Features/Workshop/Making/Shared/Components/TemplatePreviewComponents.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Shared/Components/TemplatePreviewComponents.swift
@@ -15,8 +15,17 @@ struct TemplatePreviewBody: View {
     let fetchTemplate: () async -> Void
     let onMake: () -> Void
     var onPurchase: (() -> Void)? = nil
+    var router: NavigationRouter<WorkshopRoute>? = nil
 
     @Environment(UserManager.self) private var userManager
+
+    // 구매 관련 상태
+    @State private var showPurchaseSheet = false
+    @State private var purchasePopupScale: CGFloat = 0.3
+    @State private var showPurchaseSuccessAlert = false
+    @State private var purchaseSuccessScale: CGFloat = 0.3
+    @State private var showPurchaseFailAlert = false
+    @State private var purchaseFailScale: CGFloat = 0.3
 
     /// 템플릿 보유 여부 확인
     private var isOwned: Bool {
@@ -67,6 +76,105 @@ struct TemplatePreviewBody: View {
                 }
             }
         }
+        .overlay {
+            ZStack(alignment: .center) {
+                // 구매 확인 팝업
+                if showPurchaseSheet {
+                    Color.black20
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                                purchasePopupScale = 0.3
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                                showPurchaseSheet = false
+                            }
+                        }
+
+                    if let template {
+                        PurchasePopup(
+                            title: template.name,
+                            myCoin: userManager.currentUser?.coin ?? 0,
+                            price: template.workshopPrice,
+                            scale: purchasePopupScale,
+                            onConfirm: {
+                                Task {
+                                    await handlePurchase()
+                                }
+                            }
+                        )
+                        .padding(.horizontal, 40)
+                        .padding(.bottom, 30)
+                    }
+                }
+
+                // 구매 성공 알림
+                if showPurchaseSuccessAlert {
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+                        .onTapGesture {}
+
+                    BangmarkAlert(
+                        checkmarkScale: purchaseSuccessScale,
+                        text: "구매 완료!",
+                        cancelText: "닫기",
+                        confirmText: "확인",
+                        onCancel: {
+                            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                                purchaseSuccessScale = 0.3
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                                showPurchaseSuccessAlert = false
+                            }
+                        },
+                        onConfirm: {
+                            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                                purchaseSuccessScale = 0.3
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                                showPurchaseSuccessAlert = false
+                            }
+                        }
+                    )
+                    .padding(.horizontal, 40)
+                    .padding(.bottom, 30)
+                }
+
+                // 구매 실패 알림 (코인 부족)
+                if showPurchaseFailAlert {
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+                        .onTapGesture {}
+
+                    BangmarkAlert(
+                        checkmarkScale: purchaseFailScale,
+                        text: "열쇠가 부족해요",
+                        cancelText: "취소",
+                        confirmText: "충전하기",
+                        onCancel: {
+                            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                                purchaseFailScale = 0.3
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                                showPurchaseFailAlert = false
+                            }
+                        },
+                        onConfirm: {
+                            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                                purchaseFailScale = 0.3
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                                showPurchaseFailAlert = false
+                                router?.push(.coinCharge)
+                            }
+                        }
+                    )
+                    .padding(.horizontal, 40)
+                    .padding(.bottom, 30)
+                }
+            }
+            .frame(maxHeight: .infinity)
+        }
     }
 }
 
@@ -92,12 +200,58 @@ extension TemplatePreviewBody {
                     isOwned: isOwned,
                     onMake: onMake,
                     onPurchase: onPurchase ?? {
-                        print("구매: \(template.name) - \(template.workshopPrice) 코인")
+                        showPurchaseSheet = true
+                        withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
+                            purchasePopupScale = 1.0
+                        }
                     }
                 )
             } else {
                 ProgressView()
             }
+        }
+    }
+
+    /// 구매 처리
+    private func handlePurchase() async {
+        guard let template = template else { return }
+
+        // ItemPurchaseManager를 통해 구매 처리
+        let result = await ItemPurchaseManager.shared.purchaseWorkshopItem(template, userManager: userManager)
+
+        // 팝업 닫기 애니메이션
+        await MainActor.run {
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                purchasePopupScale = 0.3
+            }
+        }
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        await MainActor.run {
+            showPurchaseSheet = false
+        }
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        switch result {
+        case .success:
+            // 성공 시 성공 알림 표시
+            showPurchaseSuccessAlert = true
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
+                purchaseSuccessScale = 1.0
+            }
+
+        case .insufficientCoins:
+            // 코인 부족 시 실패 알림 표시
+            showPurchaseFailAlert = true
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
+                purchaseFailScale = 1.0
+            }
+
+        case .failed(let message):
+            // 기타 실패 시 에러 출력
+            print("구매 실패: \(message)")
         }
     }
 }

--- a/Keychy/Keychy/Features/Workshop/Making/Templates/AcrylicPhoto/Views/AcrylicPhotoPreView.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Templates/AcrylicPhoto/Views/AcrylicPhotoPreView.swift
@@ -26,7 +26,8 @@ struct AcrylicPhotoPreView: View {
             onMake: {
                 showGuide = true
                 selectedItem = nil
-            }
+            },
+            router: router
         )
         .onChange(of: selectedItem) { _, selectedImage in
             if let selectedImage {

--- a/Keychy/Keychy/Features/Workshop/Making/Templates/NeonSign/Views/NeonSignPreview.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Templates/NeonSign/Views/NeonSignPreview.swift
@@ -17,7 +17,8 @@ struct NeonSignPreView: View {
             fetchTemplate: { await viewModel.fetchTemplate() },
             onMake: {
                 router.push(.neonSignCustomizing)
-            }
+            },
+            router: router
         )
     }
 }


### PR DESCRIPTION
## 🎯 PR 내용

워크샵 아이템 구매 기능 구현 및 구매 관련 UI/UX 개선

## Changes

### 1. 구매 로직 통합
- `ItemPurchaseManager` 생성하여 모든 워크샵 아이템 구매 로직
중앙화
  - 템플릿, 배경, 카라비너, 파티클, 사운드 등 모든 아이템 타입
지원
  - `PurchaseResult` enum으로 구매 결과 처리 (success,
insufficientCoins, failed)
  - Firebase 트랜잭션 기반 안전한 구매 처리

### 2. 구매 기능 추가
- `WorkshopPreview`: 워크샵 아이템 상세 화면에 구매 기능 추가
- `TemplatePreviewComponents`: 템플릿 프리뷰에 구매 기능 추가
- 구매 확인 팝업 → 구매 처리 → 성공/실패 알림 플로우 구현

### 3. 코인 부족 시 처리
- 코인 부족 알림에서 "충전하기" 버튼 클릭 시 `CoinChargeView`로
이동
- `TemplatePreviewComponents`와 `WorkshopPreview`에 router 연결

## Modified Files
- `ItemPurchaseManager.swift` (새로 생성)
- `WorkshopPreview.swift`
- `TemplatePreviewComponents.swift`
- `PurchasePopup.swift`
- `CollectionView.swift`
- `NeonSignPreview.swift`
- `AcrylicPhotoPreView.swift`

## 📱 스크린샷 (UI 변경 시)
https://github.com/user-attachments/assets/5b93a2e2-4827-416e-981b-cd0a8aac0cd4

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- 내 창고에 유료 구매하면 들어가도록 해야됨

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
