### PR TITLE
fix: 스와이프 제스처 수정

### DIFF
--- a/Keychy/Keychy/Core/Extensions/View+Extension.swift
+++ b/Keychy/Keychy/Core/Extensions/View+Extension.swift
@@ -27,26 +27,48 @@ extension View {
     func dismissKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
-
-    /// 네비게이션 스와이프 제스처를 활성화합니다.
-    /// `.navigationBarBackButtonHidden(true)` 사용 시에도 스와이프로 뒤로가기가 가능하도록 합니다.
-    func enableSwipeBack() -> some View {
-        self.background(SwipeBackHelper())
-    }
 }
 
-/// 네비게이션 스와이프 제스처를 활성화하는 Helper
+// MARK: - SwipeBack 관리
+
+/// 네비게이션 스와이프 제스처를 제어하는 Helper
 struct SwipeBackHelper: UIViewControllerRepresentable {
+    let isEnabled: Bool
+    
+    init(isEnabled: Bool = true) {
+        self.isEnabled = isEnabled
+    }
+    
     func makeUIViewController(context: Context) -> UIViewController {
         UIViewController()
     }
-
+    
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
         DispatchQueue.main.async {
+            // 현재 뷰컨트롤러에서 네비게이션 컨트롤러 찾기
             if let navigationController = uiViewController.navigationController {
-                navigationController.interactivePopGestureRecognizer?.isEnabled = true
-                navigationController.interactivePopGestureRecognizer?.delegate = nil
+                navigationController.interactivePopGestureRecognizer?.isEnabled = isEnabled
+                navigationController.interactivePopGestureRecognizer?.delegate = isEnabled ? nil : context.coordinator
             }
         }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+    
+    class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            return false
+        }
+    }
+}
+
+// MARK: - View Extension for SwipeBack
+extension View {
+    /// 네비게이션 스와이프 백 제스처 활성화/비활성화
+    /// - Parameter enabled: true면 스와이프 백 활성화, false면 비활성화
+    func swipeBackGesture(enabled: Bool) -> some View {
+        self.background(SwipeBackHelper(isEnabled: enabled))
     }
 }

--- a/Keychy/Keychy/Features/Workshop/Making/Shared/Components/TemplatePreviewComponents.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Shared/Components/TemplatePreviewComponents.swift
@@ -55,7 +55,6 @@ struct TemplatePreviewBody: View {
         .padding(.horizontal, 30)
         .toolbar(.hidden, for: .tabBar)
         .navigationBarBackButtonHidden(true)
-        .enableSwipeBack()
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 BackToolbarButton {

--- a/Keychy/Keychy/Features/Workshop/Making/Shared/Views/KeyringCustomizingView.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Shared/Views/KeyringCustomizingView.swift
@@ -141,6 +141,7 @@ struct KeyringCustomizingView<VM: KeyringViewModelProtocol>: View {
         }
         .ignoresSafeArea()
         .navigationBarBackButtonHidden(true)
+        .swipeBackGesture(enabled: false)
         .interactiveDismissDisabled(true)
         .alert("작업을 취소하시겠습니까?", isPresented: $showResetAlert) {
             Button("취소", role: .cancel) { }

--- a/Keychy/Keychy/Features/Workshop/Making/Templates/AcrylicPhoto/Views/AcrylicPhotoPreView.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Templates/AcrylicPhoto/Views/AcrylicPhotoPreView.swift
@@ -29,6 +29,7 @@ struct AcrylicPhotoPreView: View {
             },
             router: router
         )
+        .swipeBackGesture(enabled: false)
         .onChange(of: selectedItem) { _, selectedImage in
             if let selectedImage {
                 viewModel.loadImage(from: selectedImage)

--- a/Keychy/Keychy/Features/Workshop/Making/Templates/NeonSign/Views/NeonSignPreview.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Templates/NeonSign/Views/NeonSignPreview.swift
@@ -20,6 +20,7 @@ struct NeonSignPreView: View {
             },
             router: router
         )
+        .swipeBackGesture(enabled: true)
     }
 }
 

--- a/Keychy/Keychy/Features/Workshop/WorkshopPreview.swift
+++ b/Keychy/Keychy/Features/Workshop/WorkshopPreview.swift
@@ -73,7 +73,7 @@ struct WorkshopPreview: View {
         .padding(.horizontal, 30)
         .toolbar(.hidden, for: .tabBar)
         .navigationBarBackButtonHidden(true)
-        .enableSwipeBack()
+        .swipeBackGesture(enabled: true)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 BackToolbarButton {


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->
### 스와이프 제스처 기존 문제
- 스와이프 백 제스처를 활성화하는 모디피어를 넣으면 그 이후 router에 push 되는 모든 뷰가 스와이프 백 제스처 활성화가 돼버림.(전염됨)

### 해결?

.swipeBackGesture(enabled: true)
.swipeBackGesture(enabled: false)

이렇게 활성화하고 끌 수 있는 모디피어를 만들었어요.

true든 false든 그 이후 push되는 뷰들은 모두 전염돼요.
무슨말이냐면 true 모디피어를 가진 뷰를 스치면 그 이후 모든 뷰들 true돼버림. 
또한 false 모디피어를 가진 뷰를 스치면 그 이후 모든 뷰들 false 돼버림.

### 사용처
-> 인터렉션 씬을 포함한 뷰처럼  스와이프 백 제스처가 없어야 하는 뷰들만 false 모디피어 달아놓고,
-> 공방뷰 아이템처럼 슥슥 제스처로 백하면 좋은 뷰들은 true달아놓으면 될거 같아요.

### 특이사항
- 아크릴 키링 프리뷰 -> 사진 선택시트 -> 크롭뷰
넘어갈 때 시트가 제스쳐를 초기화 하여 false모디피어가 안먹음. 그냥 아크릴은 프리뷰뷰 부터 false 맥임.
네온사인 템플릿은 프리뷰뷰에 true -> 커마뷰에 false넣어서 그 이후 모든 뷰는 스와이프 백이 안먹음.

귀찮지만 QA하면서 모디피어 뷰 별로 하나씩 달아주면 훨씬 사용자들이 사용하기 편할 것이라고 생각됩니다.

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- 없음

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
