### PR TITLE
fix: 아이폰 16pro 기준으로 수정

### DIFF
--- a/Keychy/Keychy/Core/Components/KeyringBundle/MultiKeyringCaptureScene+Capture.swift
+++ b/Keychy/Keychy/Core/Components/KeyringBundle/MultiKeyringCaptureScene+Capture.swift
@@ -81,8 +81,8 @@ extension MultiKeyringCaptureScene {
             return nil
         }
         
-        // 고정 캡처 사이즈 (iPhone 14 기준)
-        let captureSize = CGSize(width: 390, height: 844)
+        // 고정 캡처 사이즈 (iPhone 16 Pro 기준)
+        let captureSize = CGSize(width: 402, height: 874)
 
 
         return await withCheckedContinuation { continuation in

--- a/Keychy/Keychy/Core/Components/KeyringBundle/MultiKeyringSceneView.swift
+++ b/Keychy/Keychy/Core/Components/KeyringBundle/MultiKeyringSceneView.swift
@@ -37,8 +37,8 @@ struct MultiKeyringSceneView: View {
     @State private var particleEffects: [ParticleEffect] = []
     @State private var backgroundImage: UIImage?
 
-    // 기본 화면 크기 (iPhone 14 기준)
-    private let defaultSceneSize = CGSize(width: 393, height: 852)
+    // 기본 화면 크기 (iPhone 16 Pro 기준)
+    private let defaultSceneSize = CGSize(width: 402, height: 874)
 
     init(
         keyringDataList: [MultiKeyringScene.KeyringData],


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

멀티키링씬의 절대 화면 크기를 iphone16 pro로 바꿨습니다. 
싱싱이 다시 위치랑 카라비너 사이즈로 카라비너 배경의 샘에 올려놨대요 파베수정해야됨

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->
- 기존 카라비너 들이 왼쪽 상단으로 살짝씩 이동한 것처럼 보임 -> 어차피 변경될 것.

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- 파베 이미지랑 좌표들만 수정하면 됩니다.!!

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
