### PR TITLE
Style/공방 로티 썸네일 비율 조정

### DIFF
--- a/Keychy/Keychy/Features/Workshop/WorkshopComponents.swift
+++ b/Keychy/Keychy/Features/Workshop/WorkshopComponents.swift
@@ -349,7 +349,7 @@ struct PriceOverlay<Item: WorkshopItem>: View {
                     Image(.paidIcon)
                     Spacer()
                 }
-                .padding(.top, 3)
+                .padding(.top, 7)
                 .padding(.leading, 10)
                 Spacer()
             }


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->
* 로티 나오는 썸네일 비율 수정했습니다.
* PriceOverlay 구조 변경했습니다. (Vstack HStack 활용 -> ZStack으로 변경)
(상단 HStack 아이콘과 보유 텍스트 상단 padding값이 다른데 같은 HStack으로 묶으니 '보유' 텍스트 패딩값을 맞출 수 없어서 ZStack으로 변경하고 각 아이콘들이 독립적으로 놀게 했습니다.)

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->


## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
