### PR TITLE
fix: 바텀 패딩 수정

### DIFF
--- a/Keychy/Keychy/Features/Workshop/Making/Shared/Components/TemplatePreviewComponents.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Shared/Components/TemplatePreviewComponents.swift
@@ -53,7 +53,7 @@ struct TemplatePreviewBody: View {
                     // 액션 버튼
                     actionButton
                         .adaptiveBottomPadding()
-                        .padding(.bottom, getBottomPadding(0) != 0 ? 0 : 34)
+                        .padding(.bottom, getBottomPadding(40) == 0 ? 40 : 0)
                 }
                 .padding(.horizontal, 34)
 

--- a/Keychy/Keychy/Features/Workshop/WorkshopPreview.swift
+++ b/Keychy/Keychy/Features/Workshop/WorkshopPreview.swift
@@ -72,7 +72,7 @@ struct WorkshopPreview: View {
                 
                 actionButton
                     .adaptiveBottomPadding()
-                    .padding(.bottom, getBottomPadding(0) != 0 ? 0 : 34)
+                    .padding(.bottom, getBottomPadding(40) == 0 ? 40 : 0)
             }
             .padding(.horizontal, 30)
             


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

* 아니 어떤 바보자식이 getBottomPadding(0)으로 설정함
getBottomPadding(0)으로 설정하면 패딩값을 반환해도 0을 반환하겠죠??
그래서 getBottomPadding(40)으로 설정함
수정 완료
## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->
se3
<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/35b4e577-bf46-4f25-93b3-efdc1945f1bd" />
아이폰16
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/79480e80-d835-4e99-a60d-3c8e27717d45" />

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
