### PR TITLE
fix: 첫 진입 후 파티클 안 터지는 문제 픽스

### DIFF
--- a/Keychy/Keychy/Core/Components/Keyring/KeyringDetailScene.swift
+++ b/Keychy/Keychy/Core/Components/Keyring/KeyringDetailScene.swift
@@ -235,5 +235,9 @@ class KeyringDetailScene: SKScene {
         
         // 파티클 효과 발생
         applyParticleEffect(particleId: currentParticleId)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.lastParticleTime = 0
+        }
     }
 }


### PR DESCRIPTION
## 🎯 PR 내용
lastParticleTime이 환영 효과 때문에 설정되어서 쓰로틀링에 걸리는 것 같아서 lastParticleTime = 0으로 초기화함

## 📱 스크린샷 (UI 변경 시)
X

## 🔗 관련 이슈
X

## ✅ 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
