### PR TITLE
bugfix: 푸시 알림 탭 시 NotificationGiftView로 이동 구현

### DIFF
--- a/Keychy/Keychy/App/KeychyApp.swift
+++ b/Keychy/Keychy/App/KeychyApp.swift
@@ -280,7 +280,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
         // postOfficeId 추출해서 화면 이동
         if let postOfficeId = userInfo["postOfficeId"] as? String {
-            DeepLinkManager.shared.handleDeepLink(postOfficeId: postOfficeId, type: .collect)
+            DeepLinkManager.shared.handleDeepLink(postOfficeId: postOfficeId, type: .notification)
         }
 
         completionHandler()

--- a/Keychy/Keychy/App/MainTabView.swift
+++ b/Keychy/Keychy/App/MainTabView.swift
@@ -150,18 +150,23 @@ struct MainTabView: View {
     private func handleDeepLink(postOfficeId: String, type: DeepLinkType) {
         print("키링 수신 처리 시작: \(postOfficeId)")
 
-        selectedTab = 2  // 보관함 탭 (순서 변경으로 2번으로 이동)
-
         switch type {
         case .receive:
+            selectedTab = 2  // 보관함 탭
             receivedPostOfficeId = postOfficeId
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 showReceiveSheet = true
             }
         case .collect:
+            selectedTab = 2  // 보관함 탭
             collectedPostOfficeId = postOfficeId
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 showCollectSheet = true
+            }
+        case .notification:
+            selectedTab = 0  // 홈 탭
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                homeRouter.push(.notificationGiftView(postOfficeId: postOfficeId))
             }
         }
     }

--- a/Keychy/Keychy/Core/FileManagers/DeepLinkManager.swift
+++ b/Keychy/Keychy/Core/FileManagers/DeepLinkManager.swift
@@ -9,8 +9,9 @@ import SwiftUI
 import Foundation
 
 enum DeepLinkType {
-    case receive  // 1:1 선물
-    case collect  // 배포용
+    case receive      // 1:1 선물
+    case collect      // 배포용
+    case notification // 푸시 알림
 }
 
 @Observable

--- a/Keychy/Keychy/Core/Navigation/Routes/CollectionRoute.swift
+++ b/Keychy/Keychy/Core/Navigation/Routes/CollectionRoute.swift
@@ -29,6 +29,6 @@ enum CollectionRoute: Hashable, BundleRoute {
     
     // 포장 완료
     case packageCompleteView(keyring: Keyring, postOffice: String)
-    
+
     case coinCharge
 }

--- a/Keychy/Keychy/Features/Collection/Views/CollectionTab.swift
+++ b/Keychy/Keychy/Features/Collection/Views/CollectionTab.swift
@@ -42,7 +42,7 @@ struct CollectionTab: View {
                         WidgetSettingView(router: router)
                     case .packageCompleteView(let keyring, let postOfficeId):
                         PackageCompleteView(router: router, viewModel: collectionViewModel, keyring: keyring, postOfficeId: postOfficeId)
-                        
+
                     case .coinCharge:
                         CoinChargeView(router: router)
                     }


### PR DESCRIPTION
## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

- DeepLinkType에 notification case 추가
- 푸시 알림 탭 시 type: .notification으로 처리하도록 변경
- MainTabView에서 notification 타입 처리 추가 (홈 탭으로 이동 후 NotificationGiftView push)
- 기존 collect 타입과 구분하여 올바른 화면으로 라우팅

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

https://github.com/user-attachments/assets/b91c82a2-f937-43c3-adbe-8c1bfea2a3ad


## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
