### PR TITLE
fix: 아크릴키링 카메라 크롭뷰 0사이즈 버그

### DIFF
--- a/Keychy/Keychy/Features/Workshop/Making/Templates/AcrylicPhoto/ViewModels/AcrylicPhotoVM+ImageLoad.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Templates/AcrylicPhoto/ViewModels/AcrylicPhotoVM+ImageLoad.swift
@@ -35,9 +35,7 @@ extension AcrylicPhotoVM {
 
                     self.selectedImage = uiImage
 
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        self.resetToCenter()
-                    }
+                    // resetToCenter()는 Crop 화면의 onAppear에서 호출됨 (fixedImage 설정 후)
 
                 case .failure(let error):
                     self.errorMessage = "이미지 로드 실패: \(error.localizedDescription)"

--- a/Keychy/Keychy/Features/Workshop/Making/Templates/AcrylicPhoto/Views/AcrylicPhotoPreView.swift
+++ b/Keychy/Keychy/Features/Workshop/Making/Templates/AcrylicPhoto/Views/AcrylicPhotoPreView.swift
@@ -80,8 +80,8 @@ struct AcrylicPhotoPreView: View {
                 viewModel.selectedImage = newImage
 
                 // Crop 화면으로 전환
+                // resetToCenter()는 Crop 화면의 onAppear에서 호출됨 (fixedImage 설정 후)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    viewModel.resetToCenter()
                     router.push(.acrylicPhotoCrop)
                 }
             }


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### 핵심: resetToCenter()가 너무 일찍 호출되던 문제였음.

기존에 resetToCenter()로 크롭뷰를 사진의 중앙에 오게 정렬함.
근데 이 타이밍이 사진촬영의 경우 너무 빨랐음. 
사진 로드를 안했는데, resetToCenter()가 호출.

이렇게 너무 빨리 호출해서 이 상태를 나타내는 변수가 true가 되었음.
- hasCropAreaBeenSet = true 때문에
- Crop 화면 onAppear에서 if !hasCropAreaBeenSet 조건이 false
- resetToCenter()가 다시 호출 안됨
-> 크롭뷰의 위치는 그대로 (0,0) -> 화면 좌솽단.


> 처음엔, 단순 비동기 타이밍 문제인줄 알았는데
> 그냥 호출되지 않아도 되는 곳에서 호출되어지고 있었다.
> 카메라로 자주 안만들어서 
## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

https://github.com/user-attachments/assets/d123734e-dd83-4f1e-9820-4cde184f9d4f


## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
