### PR TITLE
fix: 카라비너 변경 시 팝업 띄우기

### DIFF
--- a/Keychy/Keychy/Features/Collection/Views/Bundle/BundleEditView.swift
+++ b/Keychy/Keychy/Features/Collection/Views/Bundle/BundleEditView.swift
@@ -500,7 +500,8 @@ struct BundleEditView<Route: BundleRoute>: View {
                             viewModel: viewModel,
                             selectedCarabiner: newSelectedCarabiner,
                             onCarabinerTap: { carabiner in
-                                newSelectedCarabiner = carabiner
+                                selectCarabiner = carabiner
+                                showChangeCarabinerAlert = true
                             }
                         )
                     )


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->
뭉치 수정에서 카라비너 변경 시, '변경하시겠습니까?' alert가 뜨고 카라비너가 변경 되어야 하는데, 지금은 카라비너가 바로 변경 되는 현상이 있었습니다. 살펴보니 로직이 일부 빠진 부분이 있어서 추가했습니다.
## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #392 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
