### PR TITLE
refactor, fix: MyPageView 전체 로직 재분리,  스크롤 - 타이틀 숨김 로직 수정

### DIFF
--- a/Keychy/Keychy/Features/Home/Views/MyPage/MyPageView.swift
+++ b/Keychy/Keychy/Features/Home/Views/MyPage/MyPageView.swift
@@ -11,6 +11,14 @@ import FirebaseFirestore
 import AuthenticationServices
 import CryptoKit
 
+// MARK: - ScrollOffsetPreferenceKey
+struct ScrollOffsetPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
 struct MyPageView: View {
     @Environment(UserManager.self) private var userManager
     @Environment(IntroViewModel.self) private var introViewModel
@@ -113,24 +121,26 @@ extension MyPageView {
                 .typography(.suit15R)
         }
     }
-}
-
-// MARK: - 내 아이템, 충전하기 섹션 (아이템 정보 불러오기 필요)
-extension MyPageView {
-    /// 내아이템 - 충전하기 헤더
+    /// 내 아이템 - 충전하기
     private var itemAndCharge: some View {
         VStack(spacing: 12) {
             HStack(spacing: 0) {
                 Text("내 아이템")
                     .typography(.suit16M25)
                     .foregroundStyle(.black)
-                
+
                 Spacer()
-                
-                myPageBtn(type: .charge)
-                    
+
+                Button {
+                    router.push(.coinCharge)
+                } label: {
+                    Text("충전하기")
+                        .typography(.suit15M25)
+                        .foregroundStyle(.gray500)
+                }
+                .buttonStyle(.plain)
             }
-            
+
             HStack(spacing: 20) {
                 myCoin
                 myKeyringCount
@@ -143,76 +153,76 @@ extension MyPageView {
             .cornerRadius(15)
         }
     }
-    
-    /// 내 코인
+
     private var myCoin: some View {
         VStack(spacing: 5) {
             Image(.myCoin)
                 .padding(.vertical, 8)
                 .padding(.horizontal, 35)
-            
+
             Text("코인")
                 .typography(.suit12M)
                 .foregroundStyle(.black100)
-            
+
             Text("\(userManager.currentUser?.coin ?? 0)")
                 .typography(.nanum16EB)
                 .foregroundStyle(.main500)
         }
     }
-    
-    /// 내 보유 키링
+
     private var myKeyringCount: some View {
         VStack(spacing: 5) {
             Image(.myKeyringCount)
                 .padding(.vertical, 8)
                 .padding(.horizontal, 35)
-            
+
             Text("보유 키링")
                 .typography(.suit12M)
                 .foregroundStyle(.black100)
-            
+
             Text("\(userManager.currentUser?.keyrings.count ?? 0)/\(userManager.currentUser?.maxKeyringCount ?? 100)")
                 .typography(.nanum16EB)
                 .foregroundStyle(.main500)
         }
     }
-    
-    /// 내 보유 복사권
+
     private var myCopyPass: some View {
         VStack(spacing: 5) {
             Image(.myCopyPass)
                 .padding(.vertical, 6)
                 .padding(.horizontal, 33)
-            
+
             Text("복사권")
                 .typography(.suit12M)
                 .foregroundStyle(.black100)
-            
+
             Text("\(userManager.currentUser?.copyVoucher ?? 0)")
                 .typography(.nanum16EB)
                 .foregroundStyle(.main500)
         }
     }
-}
 
-// MARK: - 계정 관리
-extension MyPageView {
-    private var managaAccount: some View {
+    /// 계정 관리
+    private var manageAccount: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionTitle("계정 관리")
-            
-            myPageBtn(type: .changeName)
-            
+
+            Button {
+                router.push(.changeName)
+            } label: {
+                Text("닉네임 변경")
+                    .typography(.suit17M)
+                    .foregroundStyle(.black100)
+            }
+            .buttonStyle(.plain)
+
             Divider()
                 .padding(.top, 20)
         }
     }
-}
 
-// MARK: - 알림 설정
-extension MyPageView {
-    private var managaNotificaiton: some View {
+    /// 알림 설정
+    private var manageNotification: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionTitle("알림 설정")
 
@@ -248,24 +258,20 @@ extension MyPageView {
                 .padding(.top, 20)
         }
     }
-}
 
-// MARK: - 이용 안내
-extension MyPageView {
+    /// 이용 안내
     private var usingGuide: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionTitle("이용 안내")
-            
+
             VStack(alignment: .leading, spacing: 15) {
                 HStack(spacing: 0) {
                     menuItemText("앱 버전")
                         .padding(.trailing, 12)
-                    
-                    // 앱 버전 정보 가져오기!
+
                     subText("ver \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0")")
                 }
-                
-                /// Keychy 인스타 그램 연결
+
                 Button {
                     openInstagram(username: "keychy.app")
                 } label: {
@@ -279,44 +285,32 @@ extension MyPageView {
                 .padding(.top, 20)
         }
     }
-    
-    private func openInstagram(username: String) {
-        let instagramURL = URL(string: "instagram://user?username=\(username)")!
-        let webURL = URL(string: "https://www.instagram.com/\(username)")!
-        
-        if UIApplication.shared.canOpenURL(instagramURL) {
-            // 인스타그램 앱이 설치되어 있으면 앱으로 열기
-            UIApplication.shared.open(instagramURL)
-        } else {
-            // 앱이 없으면 Safari로 웹 열기
-            UIApplication.shared.open(webURL)
-        }
-    }
-}
 
-// MARK: - 약관 및 정책
-extension MyPageView {
+    /// 약관 및 정책
     private var termsOfService: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionTitle("약관 및 정책")
-            
-            /// 개인정보 처리 방침 및 이용약관
-            myPageBtn(type: .termsAndPolicy)
-            
+
+            Button {
+                router.push(.termsAndPolicy)
+            } label: {
+                Text("개인정보 처리 방침 및 이용약관")
+                    .typography(.suit17M)
+                    .foregroundStyle(.black100)
+            }
+            .buttonStyle(.plain)
+
             Divider()
                 .padding(.top, 20)
         }
     }
-}
 
-// MARK: - 로그아웃, 회원탈퇴
-extension MyPageView {
-    private var guitar: some View {
+    /// 기타 (로그아웃, 회원탈퇴)
+    private var miscellaneous: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionTitle("기타")
             VStack(alignment: .leading, spacing: 15) {
 
-                /// 로그아웃
                 Button {
                     viewModel.showLogoutAlert = true
                     withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
@@ -329,7 +323,6 @@ extension MyPageView {
                 }
                 .buttonStyle(.plain)
 
-                /// 회원탈퇴
                 Button {
                     viewModel.showDeleteAccountAlert = true
                     withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
@@ -347,58 +340,152 @@ extension MyPageView {
     }
 }
 
-// MARK: - 재사용 컴포넌트
+// MARK: - Alerts
 extension MyPageView {
-    /// 섹션 타이틀 텍스트 (회색, suit15M25, padding bottom 12)
+    /// 모든 Alert
+    private var alerts: some View {
+        Group {
+            if viewModel.showLogoutAlert { logoutAlert }
+            if viewModel.showDeleteAccountAlert { deleteAccountAlert }
+            if viewModel.showLoadingAlert { loadingAlert }
+        }
+    }
+
+    private var logoutAlert: some View {
+        ZStack {
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+                .onTapGesture {}
+
+            AccountAlert(
+                checkmarkScale: viewModel.logoutAlertScale,
+                title: "로그아웃",
+                text: "로그아웃 하시겠습니까?",
+                cancelText: "취소",
+                confirmText: "로그아웃",
+                confirmBtnColor: .main500,
+                onCancel: {
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                        viewModel.logoutAlertScale = 0.3
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        viewModel.showLogoutAlert = false
+                    }
+                },
+                onConfirm: {
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                        viewModel.logoutAlertScale = 0.3
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        viewModel.showLogoutAlert = false
+                        viewModel.logout(userManager: userManager, introViewModel: introViewModel)
+                    }
+                }
+            )
+            .padding(.horizontal, 51)
+            .padding(.bottom, 30)
+        }
+    }
+
+    private var deleteAccountAlert: some View {
+        ZStack {
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+                .onTapGesture {}
+
+            AccountAlert(
+                checkmarkScale: viewModel.deleteAccountAlertScale,
+                title: "회원 탈퇴",
+                text: """
+                    탈퇴 시 보유중인 아이템과
+                    키링 및 계정 정보는 즉시 삭제되어
+                    복구가 불가해요.
+
+                    정말 탈퇴하시겠어요?
+                    """,
+                cancelText: "취소",
+                confirmText: "탈퇴하기",
+                confirmBtnColor: .pink100,
+                onCancel: {
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                        viewModel.deleteAccountAlertScale = 0.3
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        viewModel.showDeleteAccountAlert = false
+                    }
+                },
+                onConfirm: {
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                        viewModel.deleteAccountAlertScale = 0.3
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        viewModel.showDeleteAccountAlert = false
+                        viewModel.deleteAccount(userManager: userManager, introViewModel: introViewModel)
+                    }
+                }
+            )
+            .padding(.horizontal, 51)
+            .padding(.bottom, 30)
+        }
+    }
+
+    private var loadingAlert: some View {
+        ZStack {
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+                .onTapGesture {}
+            LoadingAlert(type: .short, message: nil)
+        }
+    }
+}
+
+// MARK: - Reusable Components
+extension MyPageView {
     private func sectionTitle(_ text: String) -> some View {
         Text(text)
             .typography(.suit15M25)
             .foregroundStyle(.gray500)
             .padding(.bottom, 12)
     }
-    
-    /// 메뉴 아이템 텍스트 (검은색, suit17M)
+
     private func menuItemText(_ text: String) -> some View {
         Text(text)
             .typography(.suit16M)
             .foregroundStyle(.black100)
     }
-    
-    /// 서브 텍스트 (회색, suit12M25)
+
     private func subText(_ text: String) -> some View {
         Text(text)
             .typography(.suit12M25)
             .foregroundStyle(.gray600)
     }
-    
-    /// 뒤로가기
-    private var backToolbarItem: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
-            Button {
-                router.pop()
-            } label: {
-                Image(systemName: "chevron.left")
-            }
+
+    private func openInstagram(username: String) {
+        let instagramURL = URL(string: "instagram://user?username=\(username)")!
+        let webURL = URL(string: "https://www.instagram.com/\(username)")!
+
+        if UIApplication.shared.canOpenURL(instagramURL) {
+            UIApplication.shared.open(instagramURL)
+        } else {
+            UIApplication.shared.open(webURL)
         }
     }
 }
 
-// MARK: - 커스텀 네비게이션 바
+// MARK: - Navigation
 extension MyPageView {
     private var customNavigationBar: some View {
         CustomNavigationBar {
-            // Leading (왼쪽)
             BackToolbarButton {
                 router.pop()
             }
         } center: {
-            // Center (중앙)
             Text("마이페이지")
                 .opacity(showTitle ? 1 : 0)
         } trailing: {
-            // Trailing (오른쪽) - 빈 공간
             Spacer()
                 .frame(width: 44, height: 44)
         }
+        .opacity(viewModel.showSettingsAlert || viewModel.showDeleteAccountAlert || viewModel.showLogoutAlert || viewModel.showReauthAlert || viewModel.showLoadingAlert || viewModel.isShowingAppleSignIn ? 0 : 1)
     }
 }


### PR DESCRIPTION
## 🎯 PR 내용
<img width="338" height="190" alt="스크린샷 2025-12-17 13 25 30" src="https://github.com/user-attachments/assets/2373131d-830a-4697-bd84-69ba732554c8" />

### <수정 전> 
**스크롤을 내리면 -> 네비게이션 타이틀이 사라짐.**
**스크롤을 올리면 -> 네비게이션 타이틀이 재등장.**

하지만, 내리고/올리고의 height를 측정하여 위 로직을 동작했더니
사진처럼, 내릴땐 괜찮지만 올릴때는 최고층까지 오지 않아도 타이틀이 보이게 됨.

### <수정 후>

https://github.com/user-attachments/assets/aa841e78-4fc3-4d8a-b2ec-9ef301a7148f


## TROUBLE SHOOTING
### 최초 코드 (문제 있음)

```swift
  ScrollView {
      VStack { /* content */ }
  }
  .simultaneousGesture(
      DragGesture(minimumDistance: 10)
          .onChanged { value in
              if value.translation.height < -10 { showTitle = false }
          }
          .onEnded { value in
              if value.translation.height > 75 { showTitle = true }
          }
  )
```
  발견된 문제: 드래그 로직이었어서, 천천히 여러 번 나눠서 스크롤하면 타이틀이 다시 나타나지 않음. 
  
### 최종 코드

```swift
  VStack { /* content */ }
      .padding(...)
      .adaptiveTopPaddingAlt()
      .overlay(  // background → overlay 변경
          GeometryReader { geo in
              value: geo.frame(in: .named("scroll")).minY
          }
      )
```

#### 1. .overlay() GeometryReader 배치
- 스크롤뷰의 VStack + Padding 영역 모두를 덮습니다.

#### 2. 좌표계 설정
- .coordinateSpace(name: "scroll")  // ScrollView가 원점(0, 0)
- 맨 위가 원점이니 스크롤을 내리면 음수가 되겠죠.

#### 3. .coordinateSpace를 달아둔 뷰를 기점으로 측정 

```swift
.overlay(
              GeometryReader { geo in
                  value: geo.frame(in: .named("scroll")).minY
                  //                  ↑
                  //     ScrollView를 기준점으로 측정
              }
          )
```

#### 이런 방식으로 측정하여 ---> `showTitle` 을 토글

> **기존 주먹구구식 로직을 나름 완성된 로직으로 수정했네요.**

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #413 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
