### PR TITLE
perf: 공방 배너 fetch와 메인 뭉치 fetch 최적화

### DIFF
--- a/Keychy/Keychy/Features/Home/Views/Main/HomeView.swift
+++ b/Keychy/Keychy/Features/Home/Views/Main/HomeView.swift
@@ -77,11 +77,13 @@ struct HomeView: View {
             userManager.startNotificationListener()
         }
         .task {
-            // 최초 뷰가 나타날 때 메인 뭉치 데이터 로드
-            await viewModel.loadMainBundle(collectionViewModel: collectionViewModel, onBackgroundLoaded: onBackgroundLoaded)
+            // Workshop 배너 백그라운드 prefetch (메인 뭉치 로드를 블로킹하지 않음)
+            Task(priority: .background) {
+                await WorkshopDataManager.shared.fetchWorkshopBanner()
+            }
 
-            // Workshop 배너 미리 로드 (prefetch)
-            await WorkshopDataManager.shared.fetchWorkshopBanner()
+            // 최초 뷰가 나타날 때 메인 뭉치 데이터 로드 (우선순위)
+            await viewModel.loadMainBundle(collectionViewModel: collectionViewModel, onBackgroundLoaded: onBackgroundLoaded)
         }
         .onChange(of: viewModel.keyringDataList) { _, _ in
             // 키링 데이터가 변경되면 씬 준비 상태 초기화


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### 문제
  - Workshop 배너 prefetch가 메인 뭉치 로드를 기다리게 함
  - 키링이 늦게 표시됨

### 해결
  Workshop prefetch를 백그라운드로 실행
  
```swift
  // Before
  await loadMainBundle()        // 기다림
  await fetchWorkshopBanner()   // 또 기다림
```
> 이렇게되면 둘다 기다리고 뜨거든요 키링이

```swift
  // After
  Task(priority: .background) {
      await fetchWorkshopBanner()  // 공방 배너 페치를 백그라운드 실행으로 날렸음!
  }
  await loadMainBundle()  // 메인 작업만 기다림
```  
> 이렇게해서 공방배너 기다리지않고 번들이 뜨게

### 효과

  - 키링 더 빠르게 표시 (체감됨)
  - 두 작업 동시 진행


## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
