### PR TITLE
style: 보관함 상세뷰 저장 / 선물 버튼 위치 변경

### DIFF
--- a/Keychy/Keychy/Features/Collection/Views/Detail/CollectionKeyringDetailView+Sheet.swift
+++ b/Keychy/Keychy/Features/Collection/Views/Detail/CollectionKeyringDetailView+Sheet.swift
@@ -69,9 +69,12 @@ extension CollectionKeyringDetailView {
     private var topSection: some View {
         HStack {
             Button(action: {
-                captureAndSaveImage()
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    isSheetPresented = false
+                    showPackageAlert = true
+                }
             }) {
-                Image(.save)
+                Image(.present)
                     .resizable()
                     .frame(width: 28, height: 28)
             }
@@ -85,12 +88,9 @@ extension CollectionKeyringDetailView {
             Spacer()
             
             Button(action: {
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                    isSheetPresented = false
-                    showPackageAlert = true
-                }
+                captureAndSaveImage()
             }) {
-                Image(.present)
+                Image(.save)
                     .resizable()
                     .frame(width: 28, height: 28)
             }

--- a/Keychy/Keychy/Features/Collection/Views/Detail/CollectionKeyringDetailView.swift
+++ b/Keychy/Keychy/Features/Collection/Views/Detail/CollectionKeyringDetailView.swift
@@ -227,7 +227,7 @@ extension CollectionKeyringDetailView {
     // 하단 버튼 섹션 - 이미지 저장, 포장
     private var bottomSection: some View {
         HStack {
-            downloadImageButton
+            packageButton
             
             Spacer()
             
@@ -252,7 +252,7 @@ extension CollectionKeyringDetailView {
             
             Spacer()
             
-            packageButton
+            downloadImageButton
         }
         .padding(EdgeInsets(top: 4, leading: 16, bottom: 36, trailing: 16))
         .adaptiveBottomPadding()


### PR DESCRIPTION
## 🎯 PR 내용
### 아주 간단한 PR

### 1.0.5 배포 후 헤븐의 제안이 있었음
<img width="399" height="105" alt="스크린샷 2025-12-22 오전 12 35 36" src="https://github.com/user-attachments/assets/aefa5c25-d659-41d7-95ef-56574cf3883b" />

확실히 통일하는게 일관성에 있어서 사용성이 더 좋을 것 같아 변경했습니다.


## 📱 스크린샷 (UI 변경 시)
> 변경 Before / After
<img width="201" height="437" alt="IMG_3230" src="https://github.com/user-attachments/assets/ec95d66f-4a75-440f-85b2-32943a1c6f5b" />
<img width="201" height="437" alt="IMG_3233" src="https://github.com/user-attachments/assets/e5df31ec-1fb3-4a88-8aa2-a9e07e9dc7f5" />


## 🔗 관련 이슈
X

## ✅ 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
