### PR TITLE
fix: 딥링크 사용성 개선

### DIFF
--- a/Keychy/Keychy/Core/DeepLink/DeepLinkManager.swift
+++ b/Keychy/Keychy/Core/DeepLink/DeepLinkManager.swift
@@ -42,7 +42,7 @@ class DeepLinkManager {
     }
     
     static func createTestReceiveLink(postOfficeId: String) -> URL? {
-        return URL(string: "keychy://receive?keyringId=\(postOfficeId)")
+        return URL(string: "keychy://receive?postOfficeId=\(postOfficeId)")
     }
     
     static func createTestCollectLink(postOfficeId: String) -> URL? {


### PR DESCRIPTION
## 🎯 PR 내용
### 1. custom URL 주소 수정
- 기존 : PostOffice가 없을 시절에 만들어진 코드라 keyringId로 쿼리를 보내도록 한 url이었고 이후에 업데이트가 없었음.
- 수정 후 : keyringId로 쿼리를 보내는게 아니라 postOfficeId로 보내도록 수정함
- 다만 현재 사용되는 코드는 아니라 큰 영향은 없음 (이후에 이어질 작업 이후 아예 필요없겠다 싶으면 삭제 예정)

### 2. 웹 페이지 자동 앱 실행 로직 개선
- SNS 공유 링크 클릭 시 앱이 자동으로 실행되도록 웹 페이지 UX 개선

```
**기존:**
- SNS 인앱 브라우저 → "Safari에서 열기" → "앱에서 열기" 버튼 클릭 (3단계)

**개선:**
- SNS 인앱 브라우저 → 자동으로 앱 실행 (0단계) 
- 페이지 로드 시 Universal Link + Custom Scheme 자동 시도
- 앱 미설치 시 "앱 다운로드" 버튼 클릭으로 App Store 이동
```

```javascript
// 자동 실행 로직
1. 페이지 로드 → iOS 감지
2. Universal Link (Safari 자동 처리)
3. Custom Scheme 시도 (500ms 후)
   - keychy://receive?postOfficeId={id}
4. 앱 실행 여부 감지 (visibilitychange, pagehide)
```

> 웹 쪽 코드에서 변화가 있고 xcode쪽은 없어서 매우 간단...
> 웹 쪽 코드는 나중에 레포 이사(?)가면 웹용 레포 따로 파서 관리해야할듯...

## 📱 스크린샷 (UI 변경 시)
> 이런 느낌으로 변했습니다.
> 링크를 열면 

https://github.com/user-attachments/assets/05f5c613-49db-4828-a993-d1cff0b86265

> 앱 설치 시 -> 'Keychy'에서 이 페이지를 열겠습니까? 가 바로 뜨고 열기 버튼을 누르면 바로 열림. or 기존에 열기 버튼 누른 적 있다면 바로 열림.

https://github.com/user-attachments/assets/aafa6745-51e3-4151-b501-ef300f139130

> 앱 미설치 시 -> 기존과 동일. 다운로드 버튼을 눌러야 앱 스토어로 이동.


## 🔗 관련 이슈
X

## ✅ 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
