### PR TITLE
fix: 딥링크 -> 선물함 -> 탭바가 보이는 버그 수정

### DIFF
--- a/Keychy/Keychy/Presentation/Home/Views/Alarm/NotificationGiftView.swift
+++ b/Keychy/Keychy/Presentation/Home/Views/Alarm/NotificationGiftView.swift
@@ -51,6 +51,7 @@ struct NotificationGiftView: View {
         .ignoresSafeArea()
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
+        .toolbar(.hidden, for: .tabBar)
         .swipeBackGesture(enabled: true)
         .onAppear {
             viewModel.fetchGiftData(postOfficeId: postOfficeId, viewModel: collectionViewModel)


### PR DESCRIPTION
## 🎯 PR 내용
### 아주 간단한 PR...

문제점 : 푸쉬 알림을 눌러 딥링크를 통해 선물함으로 들어왔을 때 탭바가 보이는 현상이 있었음
해결 : 해당 뷰에 명시적으로 탭바를 hidden 처리하는 코드 추가
```
.toolbar(.hidden, for: .tabBar)
```

## 📱 스크린샷 (UI 변경 시)

> Before

https://github.com/user-attachments/assets/f8932037-c8cb-42c5-9fcb-31775c8086c3

<br>

> After

https://github.com/user-attachments/assets/8440968c-2ac3-4134-b295-9b14ac1e31c2



## 🔗 관련 이슈
X

## ✅ 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
