### PR TITLE
fix: 말풍선 키링 - 선물 받기 페이지에서 바디 크기가 작은 오류

### DIFF
--- a/Keychy/Keychy/Presentation/Collection/Views/Package/KeyringReceiveView.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Package/KeyringReceiveView.swift
@@ -323,6 +323,7 @@ struct KeyringReceiveView: View {
             ringType: ringType,
             chainType: chainType,
             bodyImage: keyring.bodyImage,
+            templateId: keyring.selectedTemplate,
             targetSize: CGSize(width: 304, height: 490),
             customBackgroundColor: .clear,
             zoomScale: 1.9,


### PR DESCRIPTION
## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->
<img width="343" height="462" alt="스크린샷 2025-12-31 14 29 50" src="https://github.com/user-attachments/assets/b5c0d76c-2638-4afb-9508-3df4931efa4c" />

### **싱싱의 버그 제보.**

### 말풍선 키링만 작은, 근본적 이유
말풍선 템플릿은 텍스트를 표시하는 용도인데.
텍스트가 읽히려면 더 크게 표시되어야함.
근데, 말풍선 템플릿은 원본 자체가 이미지가 작음.

다른 템플릿은 맥스 사이즈를 200으로 해도 (원래 모든 키링이 이렇게 되어있음.)
잘 보이지만, 말풍선 키링은 400으로 하고 있음.

그런데, KeyringReceiveView에는 이 로직이 들어가있지 않아서 발생한 문제.

### 해결 방법
KeyringCellScene+Setup.swift의 분기 로직을 동작하도록 리시브뷰에 추가하여 maxSize 400을 적용시킴.

```swift
private func createMiniScene(keyring: Keyring) -> KeyringCellScene {
        let ringType = RingType.fromID(keyring.selectedRing)
        let chainType = ChainType.fromID(keyring.selectedChain)

        let scene = KeyringCellScene(
            ringType: ringType,
            chainType: chainType,
            bodyImage: keyring.bodyImage,
            templateId: keyring.selectedTemplate,   <<< 여기가 기존엔 nil 이었음.
            targetSize: CGSize(width: 304, height: 490),
            customBackgroundColor: .clear,
```
이 크기에 대한 분기가 이미 KeyringCellScene에서 이루어지고 있으나, 
KeyringReceiveView에서 미니씬을 만드는 곳에는 이 템플릿이 "말풍선키링"이다라고 지정해주는게 없었다. 
그저 nil로 일관하고 있었고. 여기에 그냥 selectedTemplate만 넣어주면 해결. 
현재 키링의 템플릿이 무엇인지를 반환해서 넘김.

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->
<img src="https://github.com/user-attachments/assets/400887e4-04a0-4e2e-81a6-bbf6f0ff7d50" width=250>
<img src="https://github.com/user-attachments/assets/606ada9d-2071-48fb-9a28-7a9cd8dd02be" width=250>

> 안작아짐
## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #462 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
