### PR TITLE
fix: 코인차지뷰, 체인지네임뷰 네비게이션 로직 변경 (+ 🌠 보나스 - 백버튼 표시 처리)

### DIFF
--- a/Keychy/Keychy/Presentation/Home/Views/MyPage/ChangeNameView.swift
+++ b/Keychy/Keychy/Presentation/Home/Views/MyPage/ChangeNameView.swift
@@ -27,20 +27,22 @@ struct ChangeNameView: View {
             .padding(.horizontal, 20)
             .toolbar(.hidden, for: .tabBar)
             .navigationBarBackButtonHidden()
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle("닉네임 변경")
+            .toolbar {
+                backToolbarItem
+            }
+            .tint(.black)
             .dismissKeyboardOnTap()
             .ignoresSafeArea(.keyboard)
             .blur(radius: (viewModel.showSuccessAlert || viewModel.isUpdating) ? 10 : 0)
             .animation(.easeInOut(duration: 0.3), value: (viewModel.showSuccessAlert || viewModel.isUpdating))
-            .adaptiveTopPaddingAlt()
             .onAppear {
                 // 현재 닉네임으로 초기화
                 viewModel.initialize(currentNickname: userManager.currentUser?.nickname ?? "")
             }
 
             alerts
-
-            customNavigationBar
-                .ignoresSafeArea()
         }
         .swipeBackGesture(enabled: true)
         .withToast(position: .button)
@@ -138,21 +140,21 @@ extension ChangeNameView {
         }
     }
 
-    /// 커스텀 네비게이션 바
-    private var customNavigationBar: some View {
-        CustomNavigationBar {
-            // Leading (왼쪽)
-            BackToolbarButton {
+    /// Toolbar Items
+    var backToolbarItem: some ToolbarContent {
+        ToolbarItem(placement: .topBarLeading) {
+            Button {
                 router.pop()
+            } label: {
+                Image(.backIcon)
+                    .resizable()
+                    .frame(width: 32, height: 32)
             }
-        } center: {
-            // Center (중앙)
-            Text("닉네임 변경")
-        } trailing: {
-            // Trailing (오른쪽) - 빈 공간
-            Spacer()
-                .frame(width: 44, height: 44)
+            .frame(width: 32, height: 32)
+            .opacity(viewModel.showSuccessAlert || viewModel.isUpdating ? 0 : 1)
+            .allowsHitTesting(!viewModel.showSuccessAlert && !viewModel.isUpdating)
         }
+        .sharedBackgroundVisibility(viewModel.showSuccessAlert || viewModel.isUpdating ? .hidden : .visible)
     }
 }
 

--- a/Keychy/Keychy/Presentation/Workshop/Coin/CoinChargeView.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Coin/CoinChargeView.swift
@@ -55,17 +55,20 @@ struct CoinChargeView<Route: Hashable>: View {
                 .padding(.horizontal, 20)
                 .padding(.top, 25)
                 .padding(.bottom, 30)
-                .adaptiveTopPaddingAlt()
                 .navigationBarBackButtonHidden()
                 .navigationBarTitleDisplayMode(.inline)
+                .navigationTitle("충전하기")
                 .toolbar(.hidden, for: .tabBar)
+                .toolbar {
+                    backToolbarItem
+                }
+                .tint(.black)
                 .sheet(isPresented: $showPurchaseSheet) {
                     purchaseSheet
                 }
                 .allowsHitTesting(!showPurchaseSuccessAlert && !showPurchaseFailAlert)
+                .swipeBackGesture(enabled: true)
             }
-
-            customNavigationBar
 
             // Alert 딤 처리
             if showPurchaseSuccessAlert || showPurchaseFailAlert {
@@ -96,7 +99,6 @@ struct CoinChargeView<Route: Hashable>: View {
                 LoadingAlert(type: .short, message: nil)
             }
         }
-        .ignoresSafeArea()
         .task {
             // 네트워크 체크
             guard NetworkManager.shared.isConnected else {
@@ -397,22 +399,22 @@ extension CoinChargeView {
     
 }
 
-// MARK: - 커스텀네비
+// MARK: - Toolbar Items
 extension CoinChargeView {
-    private var customNavigationBar: some View {
-        CustomNavigationBar {
-            // Leading (왼쪽)
-            BackToolbarButton {
+    var backToolbarItem: some ToolbarContent {
+        ToolbarItem(placement: .topBarLeading) {
+            Button {
                 router.pop()
+            } label: {
+                Image(.backIcon)
+                    .resizable()
+                    .frame(width: 32, height: 32)
             }
-        } center: {
-            // Center (중앙)
-            Text("충전하기")
-        } trailing: {
-            // Trailing (오른쪽) - 빈 공간
-            Spacer()
-                .frame(width: 44, height: 44)
+            .frame(width: 32, height: 32)
+            .opacity(showPurchaseFailAlert || showPurchaseSuccessAlert ? 0 : 1)
+            .allowsHitTesting(!showPurchaseFailAlert && !showPurchaseSuccessAlert)
         }
+        .sharedBackgroundVisibility(showPurchaseFailAlert || showPurchaseSuccessAlert ? .hidden : .visible)
     }
 }
 


### PR DESCRIPTION
## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### 마이페이지 내 CoinCharge, ChangeName뷰에서 뒤로가기 스와이프 시 네비게이션이 중첩되는 버그

https://github.com/user-attachments/assets/95ce8477-5d9d-4418-864b-a1331627d16f

> 네비게이션 오류 영상

**영상의 첫번째 뷰처럼 화면을 완전히 스와이프 하지 않으면, 기존 화면의 네비만 보여야합니다.**
**하지만, 개인정보처리방침뷰를 제외한 2개의 뷰 케이스에선 네비게이션이 중첩됩니다.**


https://github.com/user-attachments/assets/67b64d58-3c42-4bc4-90e2-50e73ab40466

> 니베게이션 오류 해결

**문제는 예상했지만, 커스텀 네비게이션 오류였습니다.**

`MyPageView`는 SwiftUI 기본 툴바로 네비를 씁니다. 
하지만 CoinCharge, ChangeName은 커스텀 네비였어요.
그렇기에, 두 뷰간 네비게이션 애니메이션 처리가 자연스럽게 연결되지 않는 것이었습니다. 

**해결법 => CoinCharge, ChangeName뷰를 커스텀네비에서 일반네비로 변경.**

<img width="250" alt="image" src="https://github.com/user-attachments/assets/0600b62d-b500-469d-a9f8-de756971f0c4" />

그런데 잠깐.

**커스텀네비**에서 **일반네비**를 사용 하는 순간? 

### *우리 민족이 늘 겪어온 **커스텀 Alert가 등장 시, 네비게이션이 딤처리되지않는 문제** 발발.*

> 슬랙 문서 다 보셨죠? 복붙합니다. 

> [드디어 해결법을 알아냈다] 
**네비게이션 Back 버튼이 커스텀 Alert가 뜨면 안사라지던 문제!!!!!**
안녕하세요.
진짜 대박 진짜 한 2개월전에 찾았으면 진짜 행복했을 모디파이어를 찾았어요.
우리가 일전에, 고통받았던게 있었습니다.
바로, 커스텀 Alert를 띄우면 시스템 alert나 sheet처럼 자동으로 백버튼을 딤처리하거나 블러처리 되지 않는 문제요.
심지어, iOS26으로 인해 버튼의 백그라운드에는 글래스 효과가 들어가죠.
그래서 alert가 등장할때를 bool 변수로 opacity를 0으로 해도.
"<" 뒤로가기 아이콘만 사라지고 백그라운드 글래스효과는 남았어요.
그런데, 오늘 백그라운드 글래스를 키고 끄는 모디파이어를 찾았습니다.
왜 그땐 백날백시를 찾아도 못찾았을까?
왜냐면 아무런 정보가 웹에 없고 오직 apple 공식문서에만 있어서 찾기 어려웠다..

[sharedBackgroundVisibility](https://developer.apple.com/documentation/swiftui/toolbarcontent/sharedbackgroundvisibility(_:))  << 바로 이 모디파이어입니다.

### 코드 설명
```swift
var backToolbarItem: some ToolbarContent {
        ToolbarItem(placement: .topBarLeading) {
            Button {
                router.pop()
            } label: {
                Image(.backIcon)
                    .resizable()
                    .frame(width: 32, height: 32)
            }
            .frame(width: 32, height: 32)
            .opacity(showPurchaseFailAlert || showPurchaseSuccessAlert ? 0 : 1)
            .allowsHitTesting(!showPurchaseFailAlert && !showPurchaseSuccessAlert)
        }
        .sharedBackgroundVisibility(showPurchaseFailAlert || showPurchaseSuccessAlert ? .hidden : .visible)
    }
```
> 전체 코드

핵심은 
```swift
 .sharedBackgroundVisibility(viewModel.showSuccessAlert || viewModel.isUpdating ? .hidden : .visible)
```
이 모디파이어에 Alert가 등장하는 조건을 주어서, **백버튼의 글래스 백그라운드 이펙트를 제거**해주고요.

```swift
 .opacity(viewModel.showSuccessAlert || viewModel.isUpdating ? 0 : 1)
```
**opacity 조건으로 백버튼의 버튼 이미지를 없애주는 것**입니다.

이 두 조합으로, 이 버그를 파훼할 수 있었어요!

> ++ 추가적으로 기존에는 저희는 이 툴바에 frame을 지정해주지 않았어요.
원래는 이미지에만  `.frame(width: 32, height: 32)`를 지정해줬었죠. 

> 하지만 이미지에만 이 사이즈 지정을 하면,
이미지 opacity가 0이 되면서 툴바 사이즈가 고정이 아니라 레이아웃의 변동이 생깁니다. 
그로인해 프레임 지정을 해주지 않았을 때, 버튼이 오른쪽으로 살짝 이동하면서 사라지는 버그가 있었어요! 

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #472 
- **백버튼 컴포넌트를 이전에 만들었긴했지만, 변경점이 많아서 컴포넌트를 재구현해야할듯.**

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
